### PR TITLE
Fix: promote MemoryBridge → Core lazy import to typed dependency

### DIFF
--- a/omega/extensions/memory_bridge.py
+++ b/omega/extensions/memory_bridge.py
@@ -18,6 +18,8 @@ import urllib.error
 from pathlib import Path
 from datetime import datetime
 
+from centaurion_core import detect_venture
+
 
 CENTAURION_REPO = os.environ.get("CENTAURION_REPO", os.path.expanduser("~/Centaurion"))
 SUPERMEMORY_API_KEY = os.environ.get("SUPERMEMORY_API_KEY", "")
@@ -134,10 +136,11 @@ class MemoryBridgeExtension:
     Captures session summaries on end, recalls context on start.
     """
 
-    def __init__(self, agent):
+    def __init__(self, agent, classify=detect_venture):
         self.agent = agent
         self.session_venture = "general"
         self.recalled_context = None
+        self._classify = classify
 
     def on_session_start(self, session):
         """Recall recent context from Supermemory."""
@@ -156,8 +159,7 @@ class MemoryBridgeExtension:
     def on_message(self, message):
         """Detect venture from message content."""
         if hasattr(message, "content"):
-            from centaurion_core import detect_venture
-            self.session_venture = detect_venture(message.content)
+            self.session_venture = self._classify(message.content)
 
     def on_session_end(self, session):
         """Capture session summary to Supermemory."""

--- a/tests/verify-memory-bridge-di.sh
+++ b/tests/verify-memory-bridge-di.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Centaurion — MemoryBridgeExtension dependency-injection verification
+# Confirms the bridge to centaurion_core.detect_venture is a typed, visible dep
+# (not a hidden lazy import).
+# Usage: bash tests/verify-memory-bridge-di.sh
+# Exit 0 = all pass, Exit 1 = failures found
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+EXT_DIR="$REPO_ROOT/omega/extensions"
+PASS=0
+FAIL=0
+TOTAL=0
+
+pass() { PASS=$((PASS + 1)); TOTAL=$((TOTAL + 1)); echo "  ✓ $1"; }
+fail() { FAIL=$((FAIL + 1)); TOTAL=$((TOTAL + 1)); echo "  ✗ $1"; }
+
+echo ""
+echo "═══ MemoryBridgeExtension DI ═══"
+
+# D1: import is at module top (visible to AST/IDE/type-checker)
+if grep -q "^from centaurion_core import detect_venture" "$EXT_DIR/memory_bridge.py"; then
+  pass "D1: detect_venture imported at module top"
+else
+  fail "D1: detect_venture not imported at module top in memory_bridge.py"
+fi
+
+# D2: no lazy import remains inside on_message
+if grep -q "^[[:space:]]\+from centaurion_core import" "$EXT_DIR/memory_bridge.py"; then
+  fail "D2: lazy import of centaurion_core still present inside a method body"
+else
+  pass "D2: no lazy import of centaurion_core inside method bodies"
+fi
+
+# D3: no import cycle — both modules import cleanly together
+if PYTHONPATH="$EXT_DIR" python3 -c "import memory_bridge, centaurion_core" 2>/dev/null; then
+  pass "D3: memory_bridge + centaurion_core import together (no cycle)"
+else
+  fail "D3: import cycle detected between memory_bridge and centaurion_core"
+fi
+
+# D4: __init__ accepts a custom classifier
+INIT_CHECK=$(PYTHONPATH="$EXT_DIR" python3 -c "
+import inspect, memory_bridge
+sig = inspect.signature(memory_bridge.MemoryBridgeExtension.__init__)
+print('classify' in sig.parameters)
+" 2>/dev/null || echo "False")
+if [ "$INIT_CHECK" = "True" ]; then
+  pass "D4: MemoryBridgeExtension.__init__ accepts a 'classify' parameter"
+else
+  fail "D4: MemoryBridgeExtension.__init__ missing 'classify' parameter"
+fi
+
+# D5: injected classifier is actually used on_message
+DI_CHECK=$(PYTHONPATH="$EXT_DIR" python3 -c "
+import memory_bridge
+calls = []
+class M: content = 'test message'
+ext = memory_bridge.MemoryBridgeExtension(agent=None, classify=lambda t: calls.append(t) or 'aob')
+ext.on_message(M())
+print(calls == ['test message'] and ext.session_venture == 'aob')
+" 2>/dev/null || echo "False")
+if [ "$DI_CHECK" = "True" ]; then
+  pass "D5: injected classifier is called by on_message and sets session_venture"
+else
+  fail "D5: injected classifier not used by on_message"
+fi
+
+# D6: default behavior unchanged — real detect_venture still produces same tags
+DEFAULT_CHECK=$(PYTHONPATH="$EXT_DIR" python3 -c "
+import memory_bridge
+class M: content = 'working on Art of Breath facilitator certification'
+ext = memory_bridge.MemoryBridgeExtension(agent=None)
+ext.on_message(M())
+print(ext.session_venture)
+" 2>/dev/null || echo "ERR")
+if [ "$DEFAULT_CHECK" = "aob" ]; then
+  pass "D6: default classifier still detects venture correctly (aob)"
+else
+  fail "D6: default classifier broken — got '$DEFAULT_CHECK', expected 'aob'"
+fi
+
+echo ""
+echo "════════════════════════════════════════"
+echo "  MEMORY-BRIDGE DI RESULTS: $PASS passed, $FAIL failed ($TOTAL total)"
+echo "════════════════════════════════════════"
+
+if [ "$FAIL" -eq 0 ]; then
+  echo "  ✓ ALL CHECKS PASS"
+  exit 0
+else
+  echo "  ✗ $FAIL CHECK(S) FAILED"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- The only structural coupling between `Supermemory Memory Bridge` (C4) and `Centaurion Core Extension` (C3) was a runtime import hidden inside `MemoryBridgeExtension.on_message()` — invisible to AST tools, IDEs, type checkers, and graphify.
- Promote it to a module-top import + inject `detect_venture` via `__init__` so the bridge becomes EXTRACTED in the graph, statically checkable, and unit-testable.
- Backward compatible: `create_extension(agent)` signature is unchanged. Default behavior verified identical (still tags AOB content as `aob`).

## Why this matters
- **Silent break risk:** every Supermemory write is venture-tagged through this call. Rename `detect_venture` and breakage shows up only at runtime, on the next user message — writes land in `unknown`, and Supermemory's `forget` can't target by id, so cleanup is expensive.
- **Honest architecture:** grep confirmed this was the only internal lazy import across the extensions (the others — `mempalace`, `graphiti_core` — are legitimate try/except optional-dep guards). It was a one-off, not a convention. Fixing it normalizes the "no hidden cross-extension imports" norm.

## The change
```python
# was: inside on_message()
from centaurion_core import detect_venture
self.session_venture = detect_venture(message.content)

# now: module-top import + injected dep
from centaurion_core import detect_venture

class MemoryBridgeExtension:
    def __init__(self, agent, classify=detect_venture):
        ...
        self._classify = classify

    def on_message(self, message):
        if hasattr(message, "content"):
            self.session_venture = self._classify(message.content)
```

## Test plan
- [x] D1: `detect_venture` imported at module top
- [x] D2: no lazy import remains inside method bodies
- [x] D3: `memory_bridge` + `centaurion_core` import together (no cycle)
- [x] D4: `__init__` accepts a `classify` kwarg
- [x] D5: injected classifier is called by `on_message` and sets `session_venture`
- [x] D6: default classifier still detects venture correctly (`Art of Breath…` → `aob`)
- [ ] After merge: run `/graphify --update` and confirm `MemoryBridgeExtension → detect_venture` edge flips from INFERRED to EXTRACTED

Run locally:
```
bash tests/verify-memory-bridge-di.sh
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)