### PR TITLE
Install ExO 3.0 (building-an-exo) skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,7 @@ Update shared memory (Supermemory + state files):
 - `skills/aob-ops/` — AOB operations (CRM, membership, facilitators)
 - `skills/builderbee-delivery/` — BuilderBee client delivery (GHL, onboarding)
 - `skills/autoresearch/` — Autonomous overnight research iteration
+- `skills/building-an-exo/` — ExO 3.0: Intelligence Stack, DRIVE/SHAPE, REWRITE Playbook, Edge Twin (OpenExO, OS Outline v20)
 
 ## Key Files
 

--- a/skills/building-an-exo/SKILL.md
+++ b/skills/building-an-exo/SKILL.md
@@ -1,0 +1,396 @@
+---
+name: building-an-exo
+version: 1.3.0
+description: Apply ExO 3.0, the Intelligence Stack, and the REWRITE Playbook (OS Outline v20) to redesign a firm around AI. Use when a founder or CEO is rebuilding as an AI-native firm in Direct Mode (≤50) or Edge Mode (>50) with a board-mandated Edge Twin. v20 is the Edge Twin Data-Governance Pass the twin does not fork enterprise data (workflow-scoped API, ERP wins ties), Step 3 EXTRACT requires a Workflow Data Manifest, Step 5 BUILD & PROVE names the parallel run as shadow mode with four cold-start learning feeds (historical replay, shadow comparison, override capture, synthetic edge cases; falling override rate is the test of a real twin), the Four Pillars of GOVERN/ASSURE map to NIST AI RMF, OWASP LLM Top 10, and the CSA AI Controls Matrix, and Appendix F (the CIO Edge Twin Diagnostic) gates the build with red/amber/green scoring. Carries forward v15 Social Capital Crosswalk, Amazon Q sidebar, Steinberger Direct Mode proof, tokens-as-COGS; v13 Four Pillars, HIDO, Peter Principle for AI Agents, Miura-Ko L0–L5.
+
+triggers:
+  - ExO 3.0
+  - building an ExO
+  - become an ExO
+  - Exponential Organization
+  - Intelligence Stack
+  - REWRITE Playbook
+  - DRIVE
+  - SHAPE
+  - Edge Twin
+  - Edge Deployment
+  - Direct Mode
+  - Edge Mode
+  - MTP
+  - Massive Transformative Purpose
+  - agentic firm
+  - AI-native organization
+  - AI-native firm
+  - rebuild around AI
+  - redesign the company for AI
+  - "what would we build today"
+  - Backcasting Canvas
+  - Readiness Score
+  - Task Decomposition Matrix
+  - Capability Registry
+  - Permission Envelope
+  - Fiduciary Wedge
+  - MVIS
+  - Minimal Viable Intelligence Stack
+  - GOVERN/ASSURE
+  - Four Pillars
+  - Trusted Evals
+  - Searchable Logs
+  - Granular Rollback
+  - Human Review Queue
+  - HIDO
+  - HIDO Six Questions
+  - Silent Drift
+  - Quiet Drift
+  - Cross-Organizational Accountability
+  - cross-firm accountability
+  - Peter Principle for AI Agents
+  - Miura-Ko ladder
+  - Miura-Ko L0
+  - Miura-Ko L1
+  - Miura-Ko L2
+  - Miura-Ko L3
+  - Miura-Ko L4
+  - Miura-Ko L5
+  - AI-pilled ladder
+  - Dabbling Test
+  - Continuous Kill Switch
+  - Middle 60%
+  - Organizational Singularity
+  - Salim Ismail
+  - PocketOS
+  - "nine seconds to zero"
+  - intelligence density
+  - Block manifesto
+  - From Hierarchy to Intelligence
+  - RenDanHeYi
+  - Haier
+  - Cognition Labs
+  - Devin
+  - ZeroDX
+  - Social Capital primer
+  - 5-Layer Agent Stack
+  - five-layer agent stack
+  - Intelligence Action Governance Orchestration Economics
+  - Amazon Q
+  - Amazon Q sidebar
+  - AWS China outage
+  - Steinberger
+  - OpenClaw
+  - NemoClaw
+  - solo founder
+  - 36.3%
+  - tokens as COGS
+  - tokens as cost of goods sold
+  - SemiAnalysis
+  - Dylan Patel
+  - per-outcome pricing
+  - Salesforce Headless 360
+  - Headless 360
+  - Agentforce
+  - IDC AI agents forecast
+  - Karpathy
+  - maximally forkable
+  - Workflow Data Manifest
+  - data manifest
+  - does the Edge Twin fork your data
+  - data fork
+  - Edge Twin data governance
+  - source of truth
+  - ERP wins
+  - workflow-scoped API access
+  - cold-start learning
+  - shadow mode
+  - historical replay
+  - shadow comparison
+  - human-correction capture
+  - synthetic edge cases
+  - human-override rate
+  - CIO Edge Twin Diagnostic
+  - CIO diagnostic
+  - ten governance questions
+  - readiness gate
+  - red amber green
+  - SHAPE controls
+  - NIST AI RMF
+  - NIST AI Risk Management Framework
+  - OWASP LLM Top 10
+  - OWASP Top 10 for LLM Applications
+  - prompt injection
+  - sensitive-information disclosure
+  - insecure output handling
+  - excessive agency
+  - CSA AI Controls Matrix
+  - Cloud Security Alliance
+  - AICM
+  - 243 controls
+  - access is not training
+  - workload identity
+  - scoped credentials
+  - short-lived credentials
+---
+
+# Building an ExO Skill
+
+## Attribution
+
+This skill encodes the operating model published as *The Organizational Singularity* (OS Outline v20, May 2026), authored by **Salim Ismail with contributions from Dea Csuba, Charles Klasson, Kent Langley, Tony Manley, Vivek Matthews, Marconi Pereira, Ann Ralston, Gary Ralston, Miguel Angel Rojas, Patrik Sandin, Yuri van Geest, and Giovanni Pupo**. The frameworks (ExO 3.0, MTP-as-protocol, DRIVE, SHAPE, the Intelligence Stack, REWRITE, Edge Deployment, the Fiduciary Wedge, the Continuous Kill Switch, the PocketOS sidebar, the Amazon Q sidebar, the Middle 60% problem, the Four Pillars of GOVERN/ASSURE, the HIDO Six-Question Diagnostic, Silent Drift, the Peter Principle for AI Agents, Cross-Organizational Accountability, the Intelligence Stack ↔ 5-Layer Agent Stack Crosswalk, the Edge Twin Data-Governance sidebar, the Workflow Data Manifest, the Cold-Start Learning Protocol, the CIO Edge Twin Diagnostic) are the authors' intellectual property. The Miura-Ko L0–L5 ladder is attributed to Ann Miura-Ko (Floodgate, April 2026).
+
+ExO 1.0 (the SCALE/IDEAS canvas) and the original MTP construct were introduced in *Exponential Organizations* (Salim Ismail, Michael S. Malone, Yuri van Geest, 2014). ExO 3.0 supersedes SCALE/IDEAS while preserving MTP, now upgraded to a three-layer machine-readable protocol. v13 was the **Accountability & Auditability pass** over v10 (Four Pillars, HIDO, Silent Drift, Peter Principle, Miura-Ko ladder, Cross-Organizational Accountability). **v15 was the Social Capital Primer Integration pass** over v14 (industry-vocabulary crosswalk, Amazon Q enterprise-scale failure sidebar, Direct-Mode existence proof via Steinberger / OpenClaw, tokens-as-COGS, per-outcome pricing). **v20 is the Edge Twin Data-Governance Pass** over v15-v18: framework architecture is unchanged, but the book now answers the CIO's first objection (does the Edge Twin fork the enterprise data estate? No), pins data access at the workflow level (Workflow Data Manifest), names the cold-start learning protocol (parallel run as shadow mode + four learning feeds), maps the Four Pillars onto the major AI risk taxonomies (NIST AI RMF, OWASP LLM Top 10, CSA AICM), and hands the CIO a ten-question diagnostic with a red/amber/green readiness gate (Appendix F).
+
+Additional v20 sources cited in this skill: NIST, *AI Risk Management Framework* (2023), `https://www.nist.gov/itl/ai-risk-management-framework`; OWASP Foundation, *Top 10 for LLM Applications*, `https://owasp.org/www-project-top-10-for-large-language-model-applications/`; Cloud Security Alliance, *AI Controls Matrix* (243 control objectives across 18 domains, July 2025), `https://cloudsecurityalliance.org/artifacts/ai-controls-matrix`. v15 sources retained: Social Capital, *A Primer on AI Agents: The 5 Layers of AI Agents* (with Lederle Capital LLC, May 2026); Andrej Karpathy's *"maximally forkable repo"* X post (February 20, 2026); Dylan Patel / SemiAnalysis (newsletter and *Invest Like the Best* appearance, 2026); Salesforce, *Headless 360 and Agentforce Consumption Pricing* (April 15, 2026 launch); Amazon Q outage primary coverage in Fortune, MSN, TechRadar, and Engadget; IDC, *Worldwide AI Agents Forecast, 2025–2030*.
+
+This skill is an operational adaptation for AI created by Kent Langley for ExO Builders. It is not a substitute for the source. Anyone applying the material in client engagements, teaching, publishing, or commercial settings should credit the authors and cite the source at `https://openexo.com/organizational-singularity`.
+
+## Related Skills
+
+## Triggers
+
+- Founder or CEO is asking "what would we build today, with AI, from scratch?"
+- The firm has launched isolated AI pilots that produced 20–40% gains and stalled. (Phase 2 trap.)
+- Leadership has cut headcount without redesigning the underlying workflows. (Anti-case study from Chapter 10.)
+- A board or investor has asked the CEO to publish an AI strategy and the CEO doesn't have a destination architecture.
+- The firm is preparing for or executing a workforce transition affecting more than 10% of staff.
+- An AI agent already operates somewhere in the business without a documented Permission Envelope or Fiduciary Wedge.
+- The firm is single-vendor on foundation models or orchestration. (Cognitive captivity risk.)
+- A high-coordination, low-judgment workflow has been identified as a candidate for an MVIS pilot.
+- The firm is over 50 employees and any AI initiative is stalling inside an existing business unit. (Immune system signal.)
+- The firm is under 50 employees and the founder is debating whether to grow headcount or grow agency.
+- Intelligence density (revenue per employee, throughput per person, ARR growth per dollar of net burn) is on the diagnostic table.
+- A near-miss has occurred, production data damaged by an agent, an autonomous decision outside the envelope, an unsafe handover. (PocketOS pattern.)
+- The CEO needs to decide between Direct Mode and Edge Mode and is reaching for the wrong one.
+- Mission-driven entity (government, non-profit) needs an Edge Mode adaptation that respects the immune-system-is-law constraint.
+
+## Core Directives
+
+### The Three Things to Remember
+
+- MUST anchor every conversation in the three-part frame: **Destination (ExO 3.0)**, **Operating System (Intelligence Stack)**, **Playbook (REWRITE)**. Skip the rest of the framework if needed; never skip these three.
+- MUST treat the Intelligence Stack as the operating core. The other nine ExO 3.0 characteristics define the context in which the Stack operates. Build the Stack first.
+- MUST refuse the temptation to teach DRIVE without SHAPE or SHAPE without DRIVE. *DRIVE without SHAPE crashes. SHAPE without DRIVE stalls. You need both.*
+
+### ExO 3.0: The Destination Architecture
+
+- MUST replace ExO 1.0's SCALE/IDEAS split with the ten-characteristic ExO 3.0 frame: MTP plus DRIVE (5) plus SHAPE (5). The internal/external distinction is obsolete; the firm boundary has collapsed.
+- MUST encode MTP as a **three-layer machine-readable protocol**, not a poster:
+  - **Constraint Layer**, what agents are categorically forbidden from doing. Hard constraints, not aspirational values.
+  - **Decision Layer**, weighted priorities agents use when facing tradeoffs.
+  - **Identity Layer**, the cultural cohesion mechanism that replaces "the office."
+- MUST apply both MTP litmus tests before signing off:
+  1. *Could an AI agent, given only your MTP protocol, make a decision your leadership team would endorse?* If no, your MTP is a poster.
+  2. *Could that agent, given only your MTP, decide what NOT to build?* When execution is nearly free, the feature factory is the dominant failure mode.
+- MUST enforce the Five Design Conditions as principled anchors, not KPIs: AI-Centric Workflow Architecture, Recursive Improvement Infrastructure, Model Sovereignty and Governed Autonomy, Intelligence Density at Every Layer, Human Flourishing as a Binding Constraint. If any condition is violated, the architecture fails.
+- MUST locate every advantage on the Three Compounding Loops (Intelligence, Trust, Governance) and verify that no loop is being optimized at another's expense. The Intelligence Loop creates advantage. The Trust Loop scales it. The Governance Loop keeps it from collapsing under its own velocity. **Optimizing one loop at another's expense is the dominant ExO 3.0 failure mode.**
+- MUST locate the firm on the **Miura-Ko L0–L5 AI-pilled ladder** alongside the binary Dabbling Test: L0 Theater, L1 Personal Productivity, L2 Team Workflow, L3 Organizational Infrastructure (where the architecture starts to compound), L4 Compounding Operating System (where Value Moats form), L5 Virtually Self-Driving (does not yet exist). **Trust-the-ladder rule:** if the Readiness Score and the Miura-Ko level diverge sharply, trust the ladder. A high Readiness Score with a low Miura-Ko level signals a firm that has bought the architecture but hasn't deployed it, *the most expensive failure mode in the framework.*
+
+### DRIVE: The Intelligence Engine (score 1–5 each, total 25)
+
+- MUST score and stage all five components in any assessment:
+  - **D, Decision Architecture.** Two-way doors get speed; one-way doors get human gating. Map every decision type to who decides, under what conditions, with what guardrails. (Bezos, Taleb, Hart.)
+  - **R, Recursive Learning.** Workflows versioned, performance measured, improvements codified and propagated. The LEARN layer of the Stack runs this at machine speed.
+  - **I, Intelligence Stack.** The operating core (six layers + GOVERN/ASSURE). Treat as separate Stack section below; in DRIVE scoring, score whether the Stack exists and is operational.
+  - **V, Value Moat.** Five sources: proprietary data, network effects, intelligence density, reconfiguration speed, curatorial judgment. Any moat that depends on customer inertia is a wasting asset, price it and plan its replacement.
+  - **E, Elastic Agency.** Capability Registry, Graduated Authority, Decision Boundary in practice. Apply sliding talent ratios by sector; expect ~10 points/year shift toward AI as agent capability compounds.
+- MUST apply the **GOVERN-cap rule**: a high DRIVE score in the absence of GOVERN/ASSURE is overstated. Cap the DRIVE total at 13/25 until GOVERN exists in alert-only mode at minimum. This is the PocketOS lesson institutionalized.
+- MUST score the **Four Pillars of GOVERN/ASSURE** as a sub-rubric inside I = Intelligence Stack: Trusted Evals, Searchable Logs with Correlation IDs, Granular Rollback, Human Review Queue. **Cap the I score at the lowest pillar.** Most companies score 1s on at least three pillars, that is the size of the gap. **Do not deploy a new agent class until each pillar scores ≥ 3.**
+- MUST flag **Silent Drift** (the dominant production failure mode): agents do not crash, they degrade slowly. Detection requires the Trusted Evals pillar with quantified thresholds (e.g., accuracy floor + override-rate ceiling). Absent eval suites, drift is discovered in customer escalations rather than dashboards.
+- MUST flag **cognitive captivity**: if the Stack runs on a single provider's foundation models and infrastructure, the moat is around someone else's castle. Maintain inference capability across at least two model families. Own orchestration logic and fine-tuning data.
+- MUST flag **customer-side agent inversion**: design for the agent buyer, not just the human buyer. Pricing, APIs, contract terms, SLAs, increasingly read by agents on behalf of customers. The slow side of an agent-to-agent negotiation loses by definition.
+- MUST surface the **Block warning** when peer firms cite Dorsey's three-role structure as a template: Block is the canonical **DRIVE-without-SHAPE** case at corporate scale. Ask three questions in order. *Where is your Fiduciary Wedge? Where are the Four Pillars? What is your Continuous Kill Switch?* Silence is the warning.
+
+### SHAPE: The Organizational Form (score 1–5 each, total 25)
+
+- MUST score and stage all five components:
+  - **S, Safe Autonomy.** The Fiduciary Wedge (every agent decision chains to a named human owner), compliance-as-code, kill switches at every Stack layer, audit trails, agent-to-agent oversight.
+  - **H, Human Architecture.** Where human cognition creates irreplaceable value. Honest absorption modeling for the Middle 60% (the cohort that was excellent at coordination and process). Engineer the missing junior loop; without it the senior-talent pipeline runs out in a decade. Engineer the bridge against bifurcation/caste formation.
+  - **A, Adaptive Architecture.** Modularity + antifragility. Every layer of the Stack swappable, retargetable, upgradable without rebuilding the whole. Pod-based intelligence networks replace fixed hierarchies.
+  - **P, Purpose Control.** MTP as three-layer protocol (see Destination above). Compensation alone is insufficient binding; shared purpose, visible impact, judgment that shapes outcomes is what holds top talent.
+  - **E, Ecosystem Trust.** Trust as protocol: cryptographic identity, verifiable credentials, smart contracts, audit trails, mechanism design (prediction markets, quadratic voting, combinatorial auctions, retroactive funding). Design for cognitive blocs (US/China/EU divergence); treat unified ecosystem as the optimistic scenario.
+- MUST refuse to dress headcount reduction as architecture. If absorption math has not been honestly modeled, score H ≤ 2/5. The federal-workforce anti-case study is the warning.
+- MUST insist that Permission Envelopes have **scope isolation**, **approval thresholds for destructive actions**, and **soft-delete windows for irreversible operations**. The PocketOS / Cursor / Railway sequence (April 24, 2026, nine seconds from misconfigured token to gone production database and three months of backups) is the canonical SHAPE failure.
+- MUST require the **HIDO Six Questions** answered for every data object an agent reads or writes: what is it / who says so / how can it be used / legal terms / what if wrong / dispute resolution. Carry the answers as immutable, hashed, signed metadata bound to the data object. The agent spec without the data spec is a half-architecture.
+- MUST apply the **Cross-Organizational Accountability** stack before any cross-firm agent transaction: (1) policy-controlled API surface for external agents, (2) HIDO metadata travelling with the data, (3) liability framework codesigned with counterparty in advance, not in court. *If legal is not in the room when the integration is designed, the integration is a future lawsuit.* In the agent economy, **the moat is the trusted accountability stack, not the smartest agent.**
+- MUST cite **Haier (RenDanHeYi / ZeroDX)** as the strongest pre-AI existence proof that the post-hierarchy firm scales at 80K-person scale, pair with Block to show the destination is viable, not aspirational.
+
+### The Intelligence Stack: The Operating Core
+
+- MUST treat the Stack as **Boyd's OODA loop scaled to enterprise architecture and run continuously at machine speed**. Six cognitive layers plus a cross-cutting control plane:
+  - **PURPOSE**, sets objectives and constraints derived from the MTP. The constitutional layer Boyd assumed but never named.
+  - **SENSE**, collects signals (Observe).
+  - **INTERPRET**, builds context, retrieves history, frames scenarios (Orient, the most important loop).
+  - **DECIDE**, generates options and commits within the Permission Envelope (Decide).
+  - **ORCHESTRATE / ACT**, executes through tools, workflows, APIs, humans, robots, and other agents (Act).
+  - **LEARN**, evaluates outcomes, updates models, propagates improvements (the feedback loop OODA implied; we make it a layer).
+  - **GOVERN/ASSURE**, cross-cutting control plane. Logs every decision, enforces guardrails, owns kill switches. **Never off.**
+- MUST require an **Agent Specification** for every deployed agent with eight properties: Purpose, Autonomy Tier, Permission Envelope, Memory Boundary, Escalation Rules, Eval Suite, Telemetry/Audit Trail, Reusability Scope. *No spec, no agent.*
+- MUST require **Reusability Scope** in every agent spec. Agents built without it become single-purpose artifacts; agents with it become compounding capital. (McKinsey diagnostic, April 2026.)
+- MUST require the **HIDO Six Questions** for every data object the agent reads or writes. The agent spec governs *who is allowed to act and how*; HIDO governs *what may be done with each piece of evidence*. The two are symmetric, `templates/agent-specification.md` and `templates/hido-six-questions.md`.
+- MUST operationalize the **Four Pillars** as the production check on GOVERN/ASSURE: Trusted Evals, Searchable Logs with Correlation IDs, Granular Rollback, Human Review Queue. Score each 1–5. **No new agent class deploys until every pillar scores ≥ 3.**
+- MUST cite the **Four Pillars Standards Mapping (v20)** whenever a CISO, auditor, or board member asks how the Pillars relate to industry frameworks. The Pillars *operationalize* the major AI risk taxonomies; they do not restate them. NIST AI Risk Management Framework (2023) governs risk across design, development, use, and evaluation. OWASP Top 10 for LLM Applications names the failure modes the Pillars catch (prompt injection, sensitive-information disclosure, insecure output handling, excessive agency). CSA AI Controls Matrix (243 controls across 18 domains, July 2025) is the controls superset. The Pillars are the production implementation of what those frameworks specify in the abstract. See `references/four-pillars-standards-mapping.md`.
+- MUST stand up the **Minimal Viable Intelligence Stack (MVIS)** in week one regardless of which on-ramp the firm chooses: one event bus, basic agent registry, central logging, one agent per class. Every firm that skipped the MVIS regretted it within 60 days.
+- MUST apply the **Intelligence Stack ↔ Social Capital 5-Layer Agent Stack Crosswalk** when the team, vendors, or board are speaking the industry-canonical vocabulary (Intelligence / Action / Governance / Orchestration / Economics). The book's Stack is the same architecture told as an *operating model*, not as an engineering stack: PURPOSE + SENSE + INTERPRET ↔ Intelligence; DECIDE + ORCHESTRATE/ACT ↔ Action; GOVERN/ASSURE + Four Pillars ↔ Governance; ORCHESTRATE layer + Agent Specs + Architecture Blueprint ↔ Orchestration; REWRITE Steps 4–6 + Appendix D ↔ Economics. **LEARN has no industry-layer equivalent**, that is the structural bet of this book, and the asymmetric opportunity for any firm that builds it. See `references/social-capital-crosswalk.md`.
+- MUST deliver the **Amazon Q sidebar** lesson whenever an enterprise (Tier 4–5, regulated, or operating an autonomous coding agent at scale) is greenlighting deployment without a working control plane. The pattern is identical to PocketOS, the cost difference is the only thing that scales: Dec 2025 13-hour AWS China outage, Mar 2026 120,000 lost orders + 1.6M website errors, follow-on 99% North American marketplace order drop in six hours. **If Amazon can ship this, so can you.** Defense: GOVERN/ASSURE on Day 1, scoped credentials, mandatory approval thresholds on destructive endpoints, soft-delete windows, an Eval Suite that catches drift before the customer does.
+
+### REWRITE: The Migration Playbook (six steps, sequence non-negotiable)
+
+- MUST run the steps in order. **Skipping Step 1 is the fastest way to fail.**
+  1. **BACKCAST & DEFINE**, produce a Destination Architecture document from a 2–3 day facilitated executive workshop. Output: signed Destination Architecture, **Five Design Conditions instantiated as a binding exit gate** (if any one of the five is violated, the destination is incomplete and Step 1 is not done, do not advance), Edge Twin pipeline ranked, Architecture Blueprint for first Edge Twin, leadership mandate in writing.
+  2. **ASSESS & PREPARE**, run the Readiness Score across eight dimensions (Organizational Drag, AI Elevation, Work Architecture, Firm Boundary Design, Decision Autonomy, Network Structure, Reinvention Cadence, Tacit Knowledge Accessibility). Bands: 56–80 ready; 33–55 foundational work; <33 survival risk. **Add Four Pillars Maturity sub-rubric (minimum across the four pillars, ≥ 3 to deploy new agents) and Miura-Ko L0–L5 cross-reference (if score and ladder diverge, trust the ladder).** Retake every six months. Choose on-ramp (MVIS / 90-Day Sprint / Full REWRITE).
+  3. **EXTRACT**, Knowledge Archaeology + Extraction Sprint + Elicitation-First Principle + **Workflow Data Manifest (v20)**. The first agent deployed for any human shouldn't be a task executor; it should be an elicitation agent. Treat extraction with transparency and offer transition support as part of the process, not after. **Produce a one-page Workflow Data Manifest for each workflow you intend to migrate**: every data source the workflow touches, why it needs it, read or write, sensitivity tier, retention in the twin's memory, and the named data owner who approves access. The manifest is the workflow-level companion to the HIDO Six Questions per object. **The rule is binary: if you cannot state why a workflow needs a field, the Edge Twin does not get it.** The Manifest is a Step 3 exit-criterion.
+  4. **DIAGNOSE & STRIP**, Zero-Based Organization Audit and **Task Decomposition Matrix** (the single most important diagnostic). Score every task 1–5 for Agent Readiness. Appoint a CAIO with both technical fluency and P&L literacy, reporting directly to the CEO.
+  5. **BUILD & PROVE**, Decision Handover Waves (low-risk → medium → higher-judgment). Parallel-run-then-deprecate with success criteria defined before the run starts. Never more than 2–3 parallel workflows simultaneously. Budget 10–15% of savings for People Side of Parallel Runs (transition leader, retraining, severance, dual-staffing). **Cold-start learning protocol (v20):** the parallel run *is* shadow mode. Close the cold-start gap without forking corporate data using four learning feeds: (1) historical replay (curated workflow records, not the whole estate), (2) shadow comparison (every divergence between twin recommendation, human action, and outcome, logged), (3) human-correction capture (override reasons, strategic customer / policy exception / inventory constraint / legal risk; overrides are the highest-value training data the company produces), (4) synthetic edge cases (for rare/dangerous scenarios such as fraud, supply disruption, executive escalation). **The test of a real twin: the human-override rate falls over time.** If it doesn't, you don't have a twin; you have workflow automation with a chat box.
+  6. **REWIRE & EVOLVE**, replace the org chart (a latency map) with pod-based intelligence networks. Re-architect the firm boundary using sector-appropriate Elastic Agency ratios. Make the **Continuous Kill Switch** the permanent operating rhythm. Measure Organizational Half-Life at the board level.
+- MUST keep GOVERN/ASSURE alive across every step: alert-only at first, then with escalation authority, then with kill-switch capability. Not a gate between steps; a continuous layer.
+- MUST recognize that the timeline is not the point. The sequencing is. A 30-person SaaS company may move through all six steps in under a year; a 10,000-person manufacturer with legacy ERP and union contracts may take two to three years.
+
+### Edge Deployment: Where REWRITE Happens
+
+- MUST choose the deployment mode by headcount and immune-system mass:
+  - **≤50 employees: Direct Mode.** The company IS the edge. No immune system strong enough to kill transformation. Apply REWRITE to the whole company in place.
+  - **>50 employees: Edge Mode mandatory.** Spawn a 3–5 person Edge Twin plus an agent cluster, board-mandated and CEO-sponsored, reporting directly to the CEO.
+- MUST refuse to apply REWRITE inside the mothership at >50 employees. The framework can be right and still fail because the host organism rejects it. *You are not rebuilding the airplane while flying it. You are climbing into the jet engine turbine to fix it while the plane is in the air.*
+- MUST anchor the Edge Twin rationale on the **Peter Principle for AI Agents** (Varsavsky, 2026): every AI system will be pushed to the limits of its competence; the only way to discover the autonomy ceiling is by going too far and recovering. **That recovery loop IS the learning mechanism.** It cannot run on customers of record. The Edge Twin is the only safe place to discover the ceiling. **Granular Rollback** (Pillar 3) must be in place before the Edge Twin begins this work.
+- MUST fund the Edge Twin from the CEO's budget or board allocation, **never from a division budget** (immune system attack vector). Shared upside with the edge team; salaried teams optimize for survival, teams with skin optimize for results.
+- MUST answer **"Does the Edge Twin fork your data?" (v20)** before the project is funded. **No.** The Edge Twin does not copy the enterprise data estate and does not get super-user access to production databases. It gets workflow-scoped, governed API access to the specific systems one migrated workflow needs. Read and write are separated. Every call is logged on a correlation ID. Credentials are short-lived and revocable. **Operational systems remain the source of truth: if the Edge Twin and the ERP disagree, the ERP wins.** The twin is the reasoning and orchestration layer, not a second system of record. This is the first question every CIO asks; the wrong answer kills the project before it starts. See `references/edge-twin-data-governance.md`.
+- MUST hand the CIO **Appendix F: The CIO Edge Twin Diagnostic (v20)** before the first Edge Twin is funded. Ten governance questions answered in the book's framework language: (1) what is the twin allowed to do (Autonomy Tier + Decision Handover Waves), (2) what is the source of truth (operational systems; ERP wins), (3) what data does the twin need and why (Workflow Data Manifest + HIDO Six Questions), (4) does the twin train on the data (access ≠ training; pin retention, training rights, deletion rights, audit rights, model isolation in vendor contracts), (5) how do we prevent leakage (Permission Envelope + GOVERN/ASSURE catching OWASP failure modes), (6) how is identity handled (scoped workload identity, short-lived credentials, per-action logging, Searchable Logs with correlation IDs), (7) what happens when the twin is wrong (confidence score, source citation, decision rationale, human-approval rule, rollback path, audit log, exception queue: Granular Rollback + Human Review Queue), (8) who is accountable (named human, always: the Fiduciary Wedge), (9) what is the smallest safe first workflow (high coordination-to-judgment ratio, high-volume, rule-clear, measurable, reversible, low regulatory exposure; good: support triage, invoice-exception routing, order-status exceptions, renewal-risk detection; bad: hiring/firing, credit approval, strategic-account pricing, financial reporting, anything safety-critical), (10) how will we measure success (benchmarks set before parallel run; cycle time, error rate, cost per transaction, policy exceptions, experience scores; **the human-override rate must fall over time**). **Readiness gate: score each red/amber/green. Any red on 5, 6, 7, or 8 blocks the build. These four are the SHAPE controls.** Skipping them produces the PocketOS pattern. See `templates/cio-edge-twin-diagnostic.md`.
+- **Discipline note: no third autonomy ladder.** The book retains the **Autonomy Tier** (per agent spec) and the **Decision Handover Waves** (per REWRITE Step 5). Reject the source paper's "Level 0–5 autonomy maturity ladder." Do not invent a competing ladder.
+- MUST build the **Cross-Organizational Accountability stack** (policy-controlled API surface + HIDO metadata travel + codesigned liability framework) before the first cross-firm agent-to-agent transaction. The Edge Twin will eventually transact with other firms' agents; the architecture for that lives in Chapter 3.
+- MUST sequence migration **easiest first**, low-risk customer routing, pricing, inventory before procurement, scheduling, QC before resource allocation, market entry/exit. One workflow at a time. Prove. Move to the next.
+- MUST recognize that for any government, non-profit, or mission-driven entity, Direct Mode does not exist, the immune system is law. Edge deployment is the only path. Adapt for procurement timelines and political theatre, both solvable with executive-layer mandate.
+
+### The Vertical Rewrite: What Happens to Each Human Layer
+
+- MUST map the rewrite to all three human layers, not just one:
+  - **C-Suite, From Strategy Owner to Purpose Holder.** AI absorbs information synthesis, scenario modeling, strategic sensing. Leaders are left with purpose, judgment, capital allocation, accountability. The Continuous Kill Switch lives at this layer.
+  - **Middle Layer, From Coordinator to Exception Architect.** AI absorbs coordination, reporting, workflow routing, status visibility. Managers become exception architects and talent developers. This is where the Middle 60% problem and the missing junior loop live.
+  - **Coalface, From Task Executor to Agentic Operator.** AI absorbs routine execution. Frontline work becomes supervision, escalation, relationship handling, continuous improvement. Pod-based, agent-augmented, with real promotion paths into the inner ring.
+- MUST avoid the consolation-prize framing. "You are now an exception handler" is a category error dressed as opportunity unless the firm has actually engineered the new role with budget, training, and authority.
+
+### Tier-Appropriate Application
+
+- MUST adjust depth and ambition to the OpenExO ICP tier (see `/org-config/icp.md`).
+- **Tier 2 (≤50 employees, ≤$2M revenue), Direct Mode.** Apply REWRITE to the whole company. Stand up MVIS in week one. Use a 90-Day Sprint on the highest-coordination workflow. The founder can run BACKCAST themselves with a one-day workshop. SHAPE Human Architecture is small-team work; absorption math is simpler but no less honest. **v15 existence proof**, Peter Steinberger built the first version of OpenClaw on a single Friday evening in November 2025, ran 4–10 agents in parallel, pushed 6,600+ commits in January 2026 alone, surpassed 145,000 GitHub stars within weeks with no team and no revenue, and received acquisition bids from Meta and OpenAI in the same window. Solo-founded startups are now 36.3% of new ventures (Social Capital primer, May 2026). Direct Mode is not a thought experiment; it is the modal new company.
+- **Tier 3 ($2M–$10M, 20–80 employees), Direct or borderline Edge.** If headcount is climbing past 50 with managerial layers forming, spawn the Edge Twin proactively before the immune system hardens. Run DRIVE and SHAPE assessments quarterly. CAIO appointment becomes a real role at this stage, not a hat.
+- **Tier 4–5 ($10M+, 80+ employees), Edge Mode mandatory.** Spawn 3–5 person Edge Twin reporting to CEO. Board-level Continuous Kill Switch with quarterly review of Organizational Half-Life. Treat Sliding Talent Ratios as portfolio-level capital allocation. Sovereign AI capability becomes a strategic discussion, not a vendor-selection exercise.
+
+### Output Discipline
+
+- MUST produce concrete, named recommendations: a specific Destination Architecture, a scored Readiness Score with bands, a ranked Task Decomposition Matrix, named candidate workflows for Wave 1.
+- MUST cite ExO 3.0 vocabulary precisely (DRIVE, SHAPE, MVIS, Edge Twin, Fiduciary Wedge, Continuous Kill Switch, Permission Envelope, Autonomy Tier, Capability Registry). Do not invent neighboring terms or use ExO 1.0 SCALE/IDEAS vocabulary by accident.
+- MUST flag every assumption that needs human verification: "We've assumed the Stack runs on at least two model families, confirm with the CAIO before this Readiness Score is final."
+- MUST acknowledge survivorship bias when citing case examples (Cognition Labs, Pieter Levels, Klarna, Nespresso, FifthRow, Board of Innovation). The pattern is real; the outcome is not guaranteed.
+
+## Validation Checkpoints
+
+Before concluding any building-an-exo application:
+- [ ] The Destination Architecture has been named, not just gestured at.
+- [ ] **Five Design Conditions instantiated as binding Step-1 exit gate**, all five hold for this context; none violated.
+- [ ] MTP is staged as three-layer protocol (Constraint, Decision, Identity), not as poster language.
+- [ ] DRIVE has been scored across all five components with the GOVERN-cap rule applied.
+- [ ] **Four Pillars of GOVERN/ASSURE scored 1–5 each** (Trusted Evals, Searchable Logs with Correlation IDs, Granular Rollback, Human Review Queue), I capped at the lowest pillar; no new agent class deploys until each pillar ≥ 3.
+- [ ] SHAPE has been scored across all five components with honest Middle 60% absorption math.
+- [ ] **HIDO Six Questions answered** for every data object an agent reads or writes; metadata immutable, hashed, signed.
+- [ ] **Silent Drift detection**, every production agent class has named eval thresholds (accuracy floor + override-rate ceiling); drift triggers retraining or rollback.
+- [ ] **Cross-Organizational Accountability stack** in place before any cross-firm agent transaction, policy-controlled API surface, HIDO metadata travel, codesigned liability framework with counterparty.
+- [ ] The Intelligence Stack is identified at MVIS, intermediate, or full level, and the gap to MVIS is named.
+- [ ] **Miura-Ko L0–L5 level identified** alongside the Readiness Score; if they diverge, the ladder wins.
+- [ ] Every deployed or proposed agent has an Agent Specification (or a placeholder with the missing fields named).
+- [ ] Direct Mode vs. Edge Mode has been chosen on headcount and immune-system mass, not preference.
+- [ ] **Edge Twin rationale anchored on the Peter Principle for AI Agents**, Granular Rollback in place before push-to-limits-then-recover begins.
+- [ ] At least one Wave 1 workflow has been named, with success criteria for the parallel run.
+- [ ] The People Side of Parallel Runs has a budget figure (10–15% of savings) and a named transition leader.
+- [ ] Sequencing of REWRITE Steps 1–6 is intact; no step is being skipped.
+- [ ] GOVERN/ASSURE is operational at least in alert-only mode; if not, the recommendation calls this out as the first build.
+- [ ] Cognitive captivity risk has been checked (single-vendor on foundation models or orchestration).
+- [ ] If the firm cites Block as a template, the **DRIVE-without-SHAPE warning** has been delivered.
+- [ ] If the team or board is using the **Social Capital 5-Layer Agent Stack vocabulary** (Intelligence / Action / Governance / Orchestration / Economics), the **Crosswalk** has been applied and the **LEARN-layer gap** has been named as an asymmetric opportunity.
+- [ ] For any enterprise-scale agent deployment, the **Amazon Q sidebar** lessons have been applied (scoped credentials, mandatory approval thresholds on destructive endpoints, soft-delete windows, an Eval Suite that catches drift before the customer does). *If Amazon can ship this, so can you.*
+- [ ] For Direct Mode firms, the **Steinberger / OpenClaw existence proof** has been delivered: Direct Mode is not a thought experiment, it is the modal new company. Solo-founded startups are **36.3% of new ventures** as of early 2026.
+- [ ] For Tier 4–5 intelligence-dense designs, **tokens-as-COGS** has been put on the CFO's table (SemiAnalysis pattern) and **per-outcome pricing** (Salesforce Headless 360, April 15 2026) has been evaluated where the firm is the buyer of agent-native software.
+- [ ] **Edge Twin data-fork question (v20) answered:** No fork. Workflow-scoped, governed API access. Read/write separated, correlation-ID logged, credentials short-lived and revocable. Source-of-truth statement signed: if the Edge Twin and the ERP disagree, the ERP wins.
+- [ ] **Workflow Data Manifest (v20) produced** for every workflow targeted for migration: sources, why, read/write, sensitivity tier, retention in the twin, named data owner. The binary rule applied: any field that cannot be justified by the workflow does not travel to the twin. Step 3 exit criterion.
+- [ ] **Cold-start learning protocol (v20) named** for every Wave 1 workflow: parallel run as shadow mode + the four learning feeds (historical replay, shadow comparison, human-correction capture, synthetic edge cases). The falling human-override rate is the success metric of a real twin, called out explicitly.
+- [ ] **Four Pillars standards mapping (v20) cited** when CISO, auditor, or board asks: NIST AI RMF (2023), OWASP LLM Top 10, CSA AI Controls Matrix (243 controls, 18 domains, July 2025). The Pillars operationalize, do not restate.
+- [ ] **CIO Edge Twin Diagnostic (v20, Appendix F) completed** before Edge Twin funding: ten questions scored red/amber/green. Any red on 5 (leakage), 6 (identity), 7 (recovery), or 8 (accountability) blocks the build.
+- [ ] **Access vs. training distinction (v20)** pinned in writing with the vendor: retention, training rights, deletion rights, audit rights, model isolation.
+- [ ] **No third autonomy ladder (v20):** the architecture uses Autonomy Tier per agent spec plus Decision Handover Waves per REWRITE Step 5. The source's Level 0–5 maturity ladder has been rejected.
+- [ ] Source attribution to Salim Ismail and contributors is preserved on any output that will be republished or shared externally.
+
+## References
+
+### Core (Always Available)
+- `references/exo30-architecture.md`, The destination: MTP-as-protocol, DRIVE + SHAPE characteristics, Five Design Conditions (binding Step-1 exit gate in v13), Three Compounding Loops, **Miura-Ko L0–L5 ladder + Readiness Score cross-reference**, the canvas lineage (Porter → Osterwalder → Maurya → Wardley → ExO 1.0 → ExO 3.0), proof points (Block, Haier, Cognition Labs)
+- `references/intelligence-stack.md`, Six layers + GOVERN/ASSURE control plane, **Four Pillars (Trusted Evals / Searchable Logs / Granular Rollback / Human Review Queue)**, **Silent Drift sidebar**, OODA mapping, Retailer Case Study end-to-end, Agent Specification (eight properties), **HIDO Six-Question Diagnostic**, MVIS standup recipe, the PocketOS / nine-seconds-to-zero sidebar, **Amazon Q enterprise sidebar (v15)**, **Intelligence Stack ↔ Social Capital 5-Layer Stack crosswalk (v15)**
+- `references/drive-engine.md`, The five DRIVE components scored 1–5, GOVERN-cap rule, **Four Pillars sub-rubric under I**, Sliding Talent Ratios by sector, Value Moat sources (with Cognition Labs / Klarna / Pieter Levels receipts), customer-side agent inversion, cognitive captivity, **Block as DRIVE-without-SHAPE warning at corporate scale**
+- `references/shape-form.md`, The five SHAPE components scored 1–5, Fiduciary Wedge, Middle 60% absorption math, missing junior loop, bifurcation/caste risk, Permission Envelope mechanics, **Four Pillars under S**, **HIDO data-side governance**, **Cross-Organizational Accountability stack under E**, Haier RenDanHeYi existence proof
+- `references/rewrite-playbook.md`, Six-step migration with exit criteria per step, **Five Design Conditions as binding Step-1 gate**, Eight-Dimension Readiness Score banding, **Four Pillars Maturity sub-rubric**, **Miura-Ko cross-reference table**, on-ramp choices (MVIS / 90-Day Sprint / Full), Decision Handover Waves, Parallel-Run-Then-Deprecate, the People Side of Parallel Runs
+- `references/edge-deployment.md`, Direct Mode vs. Edge Mode by headcount, the five Edge Twin build steps, **Peter Principle for AI Agents as anchor rationale**, **cross-firm operation note**, failure modes and defenses, Three-Phase Studio Evolution, Path A (FifthRow / Radical Transformation) vs. Path B (Board of Innovation / Evolutionary Repositioning), mission-driven adaptation, refreshed proof points (Block, Haier, Cognition Labs)
+- `references/social-capital-crosswalk.md`, **(NEW in v15)** Verbatim Chapter 4 crosswalk text mapping the Intelligence Stack's six cognitive layers plus GOVERN/ASSURE control plane to Social Capital's industry-canonical 5-layer model (Intelligence / Action / Governance / Orchestration / Economics). Includes the Amazon Q enterprise-scale sidebar carried verbatim from the v15 source.
+- `references/v15-deltas.md`, **(NEW in v15)** Verbatim CEO Quick Start and Chapter 11 paragraphs covering the Steinberger / OpenClaw existence proof, 36.3% solo-founded-startup datum, OpenClaw / NemoClaw / Anthropic ARR signals, IDC enterprise-agent forecast (28.6M → 2.2B by 2030), SemiAnalysis tokens-as-COGS evidence, and the Salesforce Headless 360 per-outcome pricing pattern.
+- `references/edge-twin-data-governance.md`, **(NEW in v20)** The CIO's first objection answered: does the Edge Twin fork your data? No-fork architecture, workflow-scoped governed API access, read/write separation, correlation-ID logging, short-lived revocable credentials, ERP-wins source-of-truth rule, access-vs-training distinction.
+- `references/four-pillars-standards-mapping.md`, **(NEW in v20)** Mapping the Four Pillars of GOVERN/ASSURE to NIST AI Risk Management Framework (2023), OWASP Top 10 for LLM Applications, and Cloud Security Alliance AI Controls Matrix (243 controls across 18 domains, July 2025). The Pillars operationalize, they do not restate.
+- `references/cold-start-learning-feeds.md`, **(NEW in v20)** The four-feed cold-start learning protocol for the Edge Twin's parallel run as shadow mode: historical replay, shadow comparison, human-correction capture, synthetic edge cases. The falling human-override rate is the success metric of a real twin.
+
+### Templates
+- `templates/drive-scorecard.md`, DRIVE assessment template (5 components × 1–5, total 25, with GOVERN-cap rule prompt and **Four Pillars sub-rubric** under I)
+- `templates/shape-scorecard.md`, SHAPE assessment template (5 components × 1–5, total 25, with Middle 60% absorption-math prompt, **Four Pillars under S**, **HIDO check**, **Cross-Organizational Accountability check** under E)
+- `templates/rewrite-readiness-scorecard.md`, Eight-dimension Readiness Score (total 80) with banding, on-ramp recommendation, **Four Pillars Maturity sub-rubric**, and **Miura-Ko L0–L5 cross-reference**
+- `templates/backcasting-canvas.md`, Step 1 facilitated workshop canvas: Destination Architecture, Five Design Conditions instantiated, Edge Twin pipeline, mandate
+- `templates/task-decomposition-matrix.md`, Step 4 task-level audit: Role → Task → Category (judgment / pattern / coordination / creation) → Agent Readiness 1–5 → Disposition
+- `templates/agent-specification.md`, Eight-property agent contract (Purpose, Autonomy Tier, Permission Envelope, Memory Boundary, Escalation Rules, Eval Suite, Telemetry/Audit Trail, Reusability Scope)
+- `templates/hido-six-questions.md`, **(NEW in v13)** Six-question data-object diagnostic, symmetric to the Agent Specification: what is it / who says so / how can it be used / legal terms / what if wrong / dispute resolution. Required for every data object an agent reads or writes.
+- `templates/mtp-protocol.md`, Three-layer MTP authoring template (Constraint, Decision, Identity) with both litmus tests built in
+- `templates/workflow-data-manifest-template.md`, **(NEW in v20)** One-page per-workflow data manifest: sources, why this workflow needs each source, read/write, sensitivity tier, retention in the twin's memory, named data owner. Step 3 EXTRACT exit criterion. Workflow-level companion to HIDO Six Questions per object.
+- `templates/cio-edge-twin-diagnostic.md`, **(NEW in v20)** Ten governance questions for the CIO with red/amber/green scoring boxes. Any red on questions 5, 6, 7, or 8 blocks the build (these are the SHAPE controls). Mirrors Appendix F of the v20 outline.
+
+## Cross-Skill Workflows
+
+### First-Pass Building-an-ExO Intake
+When a founder or CEO asks "what would we build today, with AI, from scratch?":
+1. Start here, confirm the three-things frame (Destination, Operating System, Playbook).
+2. Score the firm with `templates/drive-scorecard.md` and `templates/shape-scorecard.md`.
+3. Score readiness with `templates/rewrite-readiness-scorecard.md`. Choose Direct vs. Edge Mode by headcount.
+4. Return here, produce a one-page Destination Architecture sketch and a named candidate workflow for Wave 1.
+
+### Stand-Up-MVIS Workflow
+When the firm needs the Minimal Viable Intelligence Stack in week one:
+1. Start here, confirm the four MVIS components (event bus, agent registry, central logging, one agent per class) plus the **Four Pillars at MVP level** (eval suite scaffold, correlation-ID logging on by default, one rollback path defined, human-review queue with named owner).
+2. Author the first Agent Specification using `templates/agent-specification.md` **and the matching HIDO Six Questions for each data object the agent will touch using `templates/hido-six-questions.md`.**
+3. Return here, confirm GOVERN/ASSURE is alert-only and the kill switch is testable; confirm Silent Drift detection thresholds are defined for the first production agent class.
+
+### Edge Twin Spawn Workflow (Tier 4–5)
+When a >50-person firm needs to launch the Edge Twin:
+1. Start here, confirm board mandate and CEO sponsorship; veto if either is missing.
+2. Apply the five Edge Twin build steps from `references/edge-deployment.md` (Spawn / Fund / REWRITE-from-Day-1 / Migrate easiest first / Become center of gravity).
+3. Run the **CIO Edge Twin Diagnostic (v20)** from `templates/cio-edge-twin-diagnostic.md` *before* funding. Any red on questions 5, 6, 7, or 8 blocks the build.
+4. Produce the **Workflow Data Manifest** for each candidate Wave 1 workflow using `templates/workflow-data-manifest-template.md`. Confirm the binary rule: no field travels to the twin without a stated workflow reason.
+5. Confirm the **no-data-fork architecture** from `references/edge-twin-data-governance.md` is signed: workflow-scoped API access, read/write separated, correlation-ID logging, short-lived revocable credentials, ERP-wins.
+6. Define the **cold-start learning protocol** for the first parallel run using `references/cold-start-learning-feeds.md`. Name the human-override-rate baseline and the falling-rate target.
+7. Return here, name the first three workflows to migrate, easiest first.
+
+### Workforce-Transition Workflow
+When a workforce reduction or restructuring is on the table:
+1. Start here, refuse to dress headcount cuts as architecture. If the Destination Architecture isn't signed and the Task Decomposition Matrix isn't scored, stop and route back to Steps 1–4.
+2. Return here, confirm the People Side of Parallel Runs has 10–15% of savings allocated and a named transition leader.
+
+### PocketOS / Silent Drift Postmortem Workflow
+When a failure has occurred, loud (autonomous agent crossed an envelope, destructive action without approval, data loss) **or quiet (Silent Drift surfaced in customer escalations)**:
+1. Start here, name the failure pattern: DRIVE-without-SHAPE, missing GOVERN, blanket-privilege token, missing approval threshold, missing soft-delete window, missing kill switch, **missing Trusted Evals (Silent Drift)**, **missing Granular Rollback**, or **missing HIDO metadata on the data object the agent acted on**.
+2. Return here, verify the eight Agent Specification properties **and the HIDO Six Questions on every data object** for every agent in the same class as the one that failed; score the **Four Pillars** for the affected agent class and bring each pillar to ≥ 3 before redeployment.
+
+### Mission-Driven Adaptation Workflow
+When the entity is government, non-profit, or other mission-driven (immune-system-is-law):
+1. Start here, confirm Edge Mode is the only path; Direct Mode does not exist.
+2. Adjust REWRITE Steps 1–6 for procurement timelines, civil service protections, and codified compliance.
+3. Frame the citizen demand forcing function (Singapore Ask Jamie, UK Bobbi, US municipal permit acceleration).
+4. Return here, name the sovereign-AI requirement (own the inference, the orchestration logic, and the fine-tuning data).
+
+#### Attribuion
+This AI skill was specially created by Kent Langley for OpenExO and its community using Founder OS (https://fos.kentlangley.com) and is based on ExO 3.0: The Organizational Singularity by Salim Ismail and Contributors. The book is available at https://openexo.com/organizational-singularity 
+
+## Changelog
+
+- **v1.3.0 (2026-05-19)**, v20 sync: *Edge Twin Data-Governance Pass*. Added the "Does the Edge Twin fork your data?" answer (no fork; workflow-scoped governed API access; read/write separated; correlation-ID logging; short-lived revocable credentials; ERP wins ties as source of truth). Added the Workflow Data Manifest as a REWRITE Step 3 exit criterion (one-page per-workflow: sources, why, read/write, sensitivity tier, retention, named data owner; binary rule). Added the cold-start learning protocol for REWRITE Step 5 (parallel run as shadow mode + four feeds: historical replay, shadow comparison, human-correction capture, synthetic edge cases; falling human-override rate is the test of a real twin). Added the Four Pillars standards mapping (NIST AI RMF 2023, OWASP LLM Top 10, CSA AI Controls Matrix 243 controls / 18 domains, July 2025; the Pillars operationalize, do not restate). Added Appendix F: The CIO Edge Twin Diagnostic, a ten-question pre-funding checklist with red/amber/green readiness gate; any red on 5/6/7/8 blocks the build. Discipline note: rejected the source's "Level 0-5 autonomy maturity ladder" to protect the existing Autonomy Tier + Decision Handover Waves. Three new references (`edge-twin-data-governance.md`, `four-pillars-standards-mapping.md`, `cold-start-learning-feeds.md`) and two new templates (`workflow-data-manifest-template.md`, `cio-edge-twin-diagnostic.md`). Source bumped from OS Outline v15 to OS Outline v20. Validation checkpoints extended for data fork, Workflow Data Manifest, cold-start learning, standards mapping, CIO Diagnostic readiness gate, access-vs-training, and no-third-ladder discipline.
+- **v1.2.0 (2026-05-12)**, v15 sync: *Social Capital Primer Integration*. Added the Intelligence Stack ↔ Social Capital 5-Layer Agent Stack Crosswalk (Intelligence / Action / Governance / Orchestration / Economics), the Amazon Q enterprise-scale sidebar (Dec 2025 13-hour AWS China outage, Mar 2026 120K lost orders / 1.6M website errors / 99% North American marketplace order drop), the Steinberger / OpenClaw solo-founder case plus the 36.3% solo-founded-startup datum as Direct Mode existence proof, SemiAnalysis tokens-as-COGS evidence, Salesforce Headless 360 per-outcome pricing (April 15 2026), and the IDC enterprise-agent forecast (28.6M agents in 2025 → 2.2B by 2030, 524% task CAGR). Two new reference docs: `references/social-capital-crosswalk.md` and `references/v15-deltas.md`. Source bumped from OS Outline v13 to OS Outline v15. Validation checkpoints extended for Crosswalk awareness, Amazon Q-style enterprise defenses, Direct Mode existence proof, and tokens-as-COGS / per-outcome pricing.
+- **v1.1.0 (2026-05-11)**, v13 sync: *Accountability & Auditability pass* over v10. Added the Four Pillars of GOVERN/ASSURE (Trusted Evals / Searchable Logs / Granular Rollback / Human Review Queue), the HIDO Six-Question Diagnostic for data objects, the Silent Drift sidebar, the Peter Principle for AI Agents (Edge Twin anchor rationale), the Miura-Ko L0–L5 ladder with Readiness Score cross-reference, and the Cross-Organizational Accountability stack as first-class concepts. New template: `templates/hido-six-questions.md`.
+- **v1.0.0 (2026-05-01)**, Initial release encoding OS Outline v10: ExO 3.0 (MTP + DRIVE + SHAPE), the Intelligence Stack, the REWRITE Playbook, the Edge Deployment model, and tier-appropriate application.

--- a/skills/building-an-exo/config.toml
+++ b/skills/building-an-exo/config.toml
@@ -1,0 +1,96 @@
+[metadata]
+author = "Kent Langley"
+created = "2026-05-01"
+updated = "2026-05-19"
+version = "1.3.0"
+license = "MIT"
+source_attribution = "Salim Ismail with contributors — The Organizational Singularity, OS Outline v20 (Edge Twin Data-Governance Pass), OpenExO Pro, May 2026"
+tags = [
+  "exo-3.0",
+  "intelligence-stack",
+  "rewrite-playbook",
+  "drive",
+  "shape",
+  "edge-twin",
+  "edge-deployment",
+  "mtp",
+  "agentic-firm",
+  "ai-native",
+  "govern-assure",
+  "four-pillars",
+  "trusted-evals",
+  "searchable-logs",
+  "granular-rollback",
+  "human-review-queue",
+  "hido",
+  "silent-drift",
+  "peter-principle-ai-agents",
+  "miura-ko-ladder",
+  "cross-organizational-accountability",
+  "permission-envelope",
+  "fiduciary-wedge",
+  "continuous-kill-switch",
+  "social-capital-crosswalk",
+  "five-layer-agent-stack",
+  "amazon-q-sidebar",
+  "steinberger-openclaw",
+  "tokens-as-cogs",
+  "semianalysis",
+  "headless-360",
+  "per-outcome-pricing",
+  "idc-agent-forecast",
+  "salim-ismail",
+  "organizational-singularity",
+  "openexo",
+  "workflow-data-manifest",
+  "edge-twin-data-governance",
+  "no-data-fork",
+  "source-of-truth",
+  "erp-wins",
+  "cold-start-learning",
+  "shadow-mode",
+  "historical-replay",
+  "shadow-comparison",
+  "human-correction-capture",
+  "synthetic-edge-cases",
+  "human-override-rate",
+  "cio-edge-twin-diagnostic",
+  "appendix-f",
+  "readiness-gate",
+  "nist-ai-rmf",
+  "owasp-llm-top-10",
+  "csa-ai-controls-matrix",
+  "aicm",
+  "standards-mapping",
+  "access-not-training",
+  "scoped-workload-identity",
+  "short-lived-credentials"
+]
+
+[defaults]
+depth = "standard"
+output_format = "markdown"
+include_templates = true
+include_premium = false
+
+[defaults.model]
+name = "claude-opus-4-7"
+temperature = 0.3
+
+[environments.quick]
+depth = "quick"
+include_templates = false
+model.temperature = 0.5
+
+[environments.deep]
+depth = "deep"
+include_premium = true
+model.name = "claude-opus-4-7"
+model.temperature = 0.2
+
+[environments.workshop]
+depth = "deep"
+include_templates = true
+include_premium = true
+model.name = "claude-opus-4-7"
+model.temperature = 0.25

--- a/skills/building-an-exo/references/cold-start-learning-feeds.md
+++ b/skills/building-an-exo/references/cold-start-learning-feeds.md
@@ -1,0 +1,120 @@
+# Cold-Start Learning for the Edge Twin: The Four-Feed Protocol
+
+> Source: *The Organizational Singularity*, OS Outline v20, Chapter 9, REWRITE Step 5 (BUILD & PROVE). Salim Ismail with contributors, May 2026. v20 names the parallel run as **shadow mode** and specifies the four learning feeds that close the cold-start gap without forking corporate data.
+
+## The Question
+
+A new Edge Twin starts with no operating history on this workflow. How does it learn fast enough to outperform the legacy workflow without the legacy workflow's full data estate?
+
+## The Position
+
+The parallel run from REWRITE Step 5 *is* the shadow mode. The twin proposes, the human acts, and the gap between the two is the richest training signal the company will ever produce. Four feeds close the cold-start gap. None of them require forking the data estate.
+
+The test of a real twin: **the human-override rate falls over time.** If it does not fall, you do not have a twin. You have workflow automation with a chat box.
+
+## Feed 1: Historical Replay
+
+A curated set of past cases for *this one workflow*. Not all data. The workflow record.
+
+**What goes in.**
+
+- Inputs (the data the workflow saw on the day it ran)
+- The human decision (what the operator did)
+- The action taken (what the system executed)
+- The outcome (what happened next)
+- The exception notes (why the case was hard, if it was hard)
+
+**What goes out.** The twin practices on the curated set before going live in shadow. Performance on replay establishes a baseline. Drift between replay performance and live shadow performance is the first warning signal.
+
+**Boundary.** Replay data is scoped to the Workflow Data Manifest. No fields outside the manifest are pulled into the replay set, even retrospectively.
+
+## Feed 2: Shadow Comparison
+
+During the parallel run, log every divergence:
+
+- Twin recommendation vs. human action
+- Twin recommendation vs. final outcome
+- Human action vs. final outcome
+
+**The signal lives in the gap.** When the twin agrees with the human and the outcome is good, you learn the workflow is well-instrumented. When the twin disagrees and the outcome favors the twin, you have evidence the twin is ahead of the human on that pattern. When the twin disagrees and the outcome favors the human, you have evidence the human is using context the twin lacks, and the next feed is what captures it.
+
+**Instrumentation.** Every divergence logged on a correlation ID. Reviewed weekly by the workflow owner, the CAIO, and the human supervisor named in the Fiduciary Wedge.
+
+## Feed 3: Human-Correction Capture
+
+Every time a validator overrides the twin, capture the reason. Categorize using a controlled taxonomy. The taxonomy is workflow-specific; common categories include:
+
+- **Strategic customer** (override to preserve a high-value relationship)
+- **Policy exception** (override required by internal policy not yet codified)
+- **Inventory constraint** (override required by physical reality the twin did not see)
+- **Legal risk** (override required by regulatory or contractual exposure)
+- **Data quality** (override because the twin's input was wrong)
+- **Edge case** (override because the workflow hit a pattern the twin had not seen)
+
+**Why this feed is the highest-value.** A workflow generates thousands of decisions and dozens of overrides. The overrides are the rare, expensive, judgment-heavy events. They carry more learning signal per case than every routine decision combined.
+
+**Operational rule.** No override is captured without a reason from the taxonomy. *No reason, no override.* This is enforced in the validator UI.
+
+## Feed 4: Synthetic Edge Cases
+
+For rare or dangerous scenarios, generate synthetic cases so the twin practices on realistic patterns without touching sensitive records.
+
+**Common synthetic scopes.**
+
+- **Fraud** (synthetic transaction patterns that mimic known fraud signatures)
+- **Supply disruption** (synthetic order, inventory, and shipment patterns for major-disruption scenarios)
+- **Executive escalation** (synthetic patterns of high-visibility, high-pressure cases)
+- **Regulatory edge** (synthetic patterns for cases sitting on a policy line)
+- **Adversarial input** (synthetic prompt-injection and OWASP failure patterns)
+
+**Generation.** Use the workflow's own data schema. Generate with parameters set by the workflow owner. Validate against the HIDO Six Questions for every synthetic object. Synthetic cases carry their own metadata flag so they never contaminate the production analytics.
+
+**Boundary.** Synthetic data is generated, not copied. No real sensitive records are duplicated into the synthetic set. This is how rare-event practice happens without leakage.
+
+## The Success Metric: Falling Human-Override Rate
+
+A twin that does not improve is not a twin. The metric that proves the twin is real is the **falling human-override rate** over time.
+
+**Baseline.** Measured on Day 1 of the parallel run. Typically high (50-80% override rate is common when the twin is new and the workflow is complex).
+
+**Target.** Workflow-specific. Set by the workflow owner. A reasonable target for Wave 1 workflows is *the override rate falls by half within 60 days of parallel-run start*. The number matters less than the *trend*.
+
+**The trend check.** Reviewed weekly. If the trend is not falling after the first month, treat it as a workflow signal, not a model signal. Common root causes include:
+
+- The workflow is judgment-heavy and Wave 1 was the wrong placement (move to Wave 2 or Wave 3)
+- The override taxonomy is wrong (too coarse, too fine, missing categories)
+- The historical replay set was too narrow (rare events not represented)
+- The human validators are overriding for inertia, not for cause (escalate to leadership)
+
+## Mapping to GOVERN/ASSURE
+
+The four feeds are not separate from the Four Pillars. They are *how* the Pillars hold during cold-start.
+
+| Feed | Pillar that enforces it |
+|---|---|
+| Historical replay | Trusted Evals (the replay set is the eval set) |
+| Shadow comparison | Searchable Logs (correlation-ID logging is the comparison instrumentation) |
+| Human-correction capture | Human Review Queue (the queue is where corrections happen) |
+| Synthetic edge cases | Trusted Evals (rare-event eval suite) |
+
+If a pillar is below 3/5, the feed it supports is unreliable, and the cold-start protocol has a hole in it.
+
+## The Failure Mode
+
+Treating the parallel run as a *demo* instead of a *learning protocol*. The twin runs in parallel for 30 days, the team declares it ready, the legacy workflow is deprecated, and the override rate is never tracked again. Six months later the twin has drifted (Silent Drift, see `references/intelligence-stack.md`) and nobody noticed.
+
+The defense. The four feeds run continuously, not just during the parallel run. Historical replay is the eval set. Shadow comparison is the divergence log. Human-correction capture is the override taxonomy. Synthetic edge cases are the rare-event eval suite. All four feed the LEARN layer of the Stack, which is the structural reason intelligence-dense firms compound (see `references/intelligence-stack.md`).
+
+## The Cold-Start Sign-Off Checklist
+
+Before the first parallel run begins:
+
+- [ ] Workflow Data Manifest signed (see `templates/workflow-data-manifest-template.md`)
+- [ ] Historical replay set curated and the eval baseline run
+- [ ] Shadow comparison logging instrumented with correlation IDs
+- [ ] Human-correction taxonomy defined and enforced in the validator UI
+- [ ] Synthetic edge-case generators configured for the workflow's rare-event scopes
+- [ ] Human-override rate baseline measured, target named, weekly review on the calendar
+- [ ] Workflow owner, CAIO, and Fiduciary-Wedge supervisor confirmed for weekly review
+
+If any line is unsigned, the parallel run is a pilot, not a Step 5 BUILD & PROVE.

--- a/skills/building-an-exo/references/drive-engine.md
+++ b/skills/building-an-exo/references/drive-engine.md
@@ -1,0 +1,147 @@
+# DRIVE: The Intelligence Engine
+
+> Source: *The Organizational Singularity*, OS Outline v20, Chapter 3 (DRIVE) and Chapter 4 (Intelligence Stack). Salim Ismail with contributors, May 2026. See also `openexo-fOS/completed-projects/OS_v20/drive-toolkit-v20/`. The v13 DRIVE scoring template added a **Four Pillars sub-rubric** under I and an **HIDO Six-Questions checklist** for any agent acting on customer-of-record data. v15 carried the same DRIVE template and added the Intelligence Stack and 5-Layer Agent Stack Crosswalk note inside I (translate at the boundary; LEARN has no industry-layer equivalent, see `references/social-capital-crosswalk.md`). v20 adds a Four Pillars standards-mapping footnote inside I tying the Pillars to NIST AI RMF, the OWASP LLM Top 10, and the CSA AI Controls Matrix (see `references/four-pillars-standards-mapping.md`). The DRIVE rubric itself is unchanged.
+
+DRIVE is the intelligence engine of ExO 3.0. Five components, each scored 1–5, total of 25.
+
+## D: Decision Architecture
+
+How decisions get made, what's automated, what's escalated, what's reserved for humans.
+
+Every decision type maps to: who decides (human, agent, hybrid), under what conditions, with what guardrails. **Two-way doors (reversible) get speed; one-way doors (irreversible) get human gating. Nothing fragile in the middle.**
+
+*Sources: Bezos (two-way / one-way doors), Taleb (barbell strategy), Hart (incomplete contracts).*
+
+**Scoring anchor:**
+- 1, Decisions exclusively human, all routed through approval chains.
+- 3, Some decision categories mapped to agents under guardrails; many still escalate by default.
+- 5, Every decision class has a defined Agency Map; reversibility tested; one-way doors gated; fragile middle eliminated.
+
+## R: Recursive Learning
+
+The organization's capacity to learn faster than the environment changes.
+
+Workflows are versioned. Performance is measured. Improvements are codified and propagated. The LEARN layer of the Intelligence Stack does this at machine speed.
+
+*Sources: Senge (learning organization), McGrath (reconfiguration), Anthropic / OpenAI (RLHF and continuous training patterns).*
+
+**Scoring anchor:**
+- 1, Lessons trapped in postmortems and Slack threads; no propagation mechanism.
+- 3, Some workflows versioned; learnings reach adjacent teams within weeks.
+- 5, LEARN layer operational; improvements codified and propagated at machine speed; recursive cadence built into compensation.
+
+## I: Intelligence Stack
+
+The operating core. Six layers + GOVERN/ASSURE control plane (full architecture in `intelligence-stack.md`). This is what replaces the org chart.
+
+In DRIVE scoring, score whether the Stack exists and is operational at minimum viable level.
+
+**Scoring anchor:**
+- 1, Isolated AI tools, no Stack architecture.
+- 3, MVIS operational (event bus, agent registry, central logging, one agent per class).
+- 5, Full six-layer Stack operational with GOVERN/ASSURE in kill-switch-capable mode and cross-layer learning.
+
+### Four Pillars Sub-Rubric (v13)
+
+Inside I, score each of the **Four Pillars of GOVERN/ASSURE** separately, 1–5:
+
+1. **Trusted Evals**, every agent has a continuously-running test set.
+2. **Searchable Logs with Correlation IDs**, every decision recoverable from the trail alone.
+3. **Granular Rollback**, any single agent revertible to last week's prompt, last month's model, last quarter's policy version.
+4. **Human Review Queue**, anything touching money, legal text, or a customer-of-record routes to a named human with SLAs.
+
+**Most companies score 1s.** Cap the I score at the lowest pillar. Do not deploy a new agent class until each pillar scores ≥3. See `intelligence-stack.md` for the underlying rationale.
+
+## V: Value Moat
+
+Where defensible advantage comes from when every firm has access to the same models. **Five sources:**
+
+1. **Proprietary Data**, The Stack learns things competitors can't.
+2. **Network Effects**, More participants generate more intelligence.
+3. **Intelligence Density**, Doing more with fewer humans. **Cognition Labs (Devin): 73× ARR growth in 9 months, team of 14 people, total net burn under $20M, enterprise adoption at Goldman Sachs and Citi.** Klarna: AI customer service agent replacing 700 FTE agents, $2–3M deployment, $40M margin gain. Pieter Levels: $3M ARR, zero employees.
+4. **Reconfiguration Speed**, Moving through transient advantages faster than competitors.
+5. **Curatorial Judgment**, When execution is nearly free, taste becomes the moat. *(Ann Miura-Ko, April 2026.)*
+
+### Customer-Side Agent Inversion
+
+Every moat analysis until 2026 assumed firms deployed agents *against* a customer base of humans. That assumption breaks in 2026.
+
+Krivkovich: *"Imagine a customer has an agent that can move money frictionlessly across bank accounts to seek the best rate. That fundamentally changes the moat that has existed in financial services since the beginning of time."*
+
+Three implications:
+
+- **Inertia moats are now wasting assets.** If your moat is "customers don't switch because switching is annoying," your moat has a measurable half-life. Price it. Plan its replacement.
+- **Design for the agent buyer, not just the human buyer.** Pricing, APIs, contract terms, SLAs, increasingly read by agents on behalf of customers. The firm whose offerings are legible to other firms' agents wins agent-mediated dealflow.
+- **Counter-agent strategy.** If your customer's agent is shopping you on price every millisecond, you need an agent on your side responding at machine speed. The slow side of an agent-to-agent negotiation loses by definition.
+
+### Cognitive Captivity
+
+If your Stack runs on a single provider's foundation models and infrastructure, your moat is around someone else's castle. Foundation model pricing is dropping today. It will not drop forever.
+
+**Mitigation:** Maintain inference capability across at least two model families. Own your orchestration logic and fine-tuning data.
+
+**Scoring anchor:**
+- 1, Pure inertia moat; single model vendor; no proprietary data, network effects, or curatorial assets.
+- 3, Mix of inertia and one durable source; multi-vendor inference but single orchestration vendor.
+- 5, Two or more durable moat sources demonstrably compounding; multi-family inference; owned orchestration and fine-tuning data.
+
+## E: Elastic Agency
+
+The workforce is a single pool of distributed agency, some human, some synthetic, some internal, some external, orchestrated by the Intelligence Stack.
+
+**Three mechanisms replace the traditional org chart:**
+
+- **Capability Registry**, A live registry of every capability (human and agent) with current allocation, quality ratings, availability. Organizations don't hire. They compose.
+- **Graduated Authority**, New agents (human or AI) start with narrow authority that expands based on demonstrated performance. Authority is earned, not granted.
+- **Decision Boundary in practice**, Every major decision type maps to an Agency Map: who or what has authority, the scope, the escalation path.
+
+### Sliding Talent Ratios by Sector (directional projections)
+
+| Sector | AI / Agents | Internal Humans | Elastic External |
+|---|---|---|---|
+| Information-centric (marketing, software, consulting) | ~70% | ~20% | ~10% |
+| Hybrid (manufacturing, logistics, retail) | ~50% | ~30% | ~20% |
+| Regulated (financial services, healthcare, gov) | ~40% | ~35% | ~25% |
+
+Expect these ratios to shift ~10 points toward AI every 10 months as agent capability compounds.
+
+**Scoring anchor:**
+- 1, Fixed org chart, no Capability Registry, no agent / human composition logic.
+- 3, Capability Registry live, Graduated Authority used for new hires, sliding ratios understood.
+- 5, Capability Registry is the org chart; composition replaces hiring; ratios tracked quarterly.
+
+## The GOVERN-Cap Rule
+
+A high DRIVE score in the absence of GOVERN/ASSURE is overstated.
+
+**Cap the DRIVE total at 13/25 until GOVERN exists in alert-only mode at minimum.**
+
+This is the PocketOS lesson institutionalized: the organization with strong DRIVE and absent GOVERN is a nine-second-to-zero waiting to happen.
+
+GOVERN/ASSURE progression:
+- Absent → cap DRIVE at 13.
+- Alert-only → no cap, but flag in the SHAPE Safe Autonomy review.
+- Escalation authority → no cap; SHAPE-S can score above 3.
+- Kill-switch capable → no cap; SHAPE-S can score 5.
+
+### The Block Warning: DRIVE-Without-SHAPE at Corporate Scale (v13)
+
+In March 2026, Block laid off 4,000 employees (~40% of workforce) and Jack Dorsey + Roelof Botha (Sequoia) published *"From Hierarchy to Intelligence,"* a 4,000-word manifesto replacing traditional management with a three-role structure: Individual Contributors, Directly Responsible Individuals (DRIs), and Player-Coaches. No permanent middle management. **Executed in one quarter what consultants describe as a five-year roadmap.**
+
+Block is the cleanest live test of the Coasean-collapse thesis at corporate scale, **and the canonical DRIVE-without-SHAPE warning**. The architecture has no GOVERN/ASSURE equivalent, no Fiduciary Wedge mapping, no compliance-as-code, no kill-switch mechanisms. **For a $50B+ payments company in regulated financial services, this is not a minor oversight.**
+
+Diagnostic: when a peer firm pitches "we did what Block did," ask three questions in order. *Where is your Fiduciary Wedge? Where are the Four Pillars? What is your Continuous Kill Switch?* If the answers are silence, you are watching DRIVE-without-SHAPE in slow motion.
+
+## Worked Example: Meridian Health Systems (DRIVE = 11/25)
+
+| Component | Score | Reasoning |
+|---|---|---|
+| D, Decision Architecture | 2 | Clinical decisions still routed through five-layer approval; no two-way / one-way mapping. |
+| R, Recursive Learning | 2 | Quarterly QA reviews; lessons stay inside individual departments. |
+| I, Intelligence Stack | 3 | MVIS standing up; SENSE and INTERPRET partial. |
+| V, Value Moat | 2 | Inertia moat (insurance contracts); one source of proprietary clinical data. |
+| E, Elastic Agency | 2 | Static org chart; no Capability Registry. |
+| **Raw total** | **11/25** | |
+| **GOVERN status** | **Alert-only** | No cap applied. |
+
+Meridian sits in the "foundational work needed" band. Step 1 (Backcast) and Step 2 (MVIS + 90-Day Sprint on a Wave 1 workflow) come before any aspirational DRIVE-5 architecture work.

--- a/skills/building-an-exo/references/edge-deployment.md
+++ b/skills/building-an-exo/references/edge-deployment.md
@@ -1,0 +1,160 @@
+# Edge Deployment: Why Transformation Can't Happen in the Core
+
+> Source: *The Organizational Singularity*, OS Outline v20, Chapter 8, The Edge Deployment Model, and Chapter 10, Mission-Driven Organizations. Salim Ismail with contributors, May 2026. v13 anchored the Edge Twin rationale on the **Peter Principle for AI Agents** (push-to-limits-then-recover is the actual learning mechanism) and added a back-reference to Chapter 3's **Cross-Organizational Accountability** stack for any Edge Twin that transacts with other firms' agents. **v15** added the Steinberger / OpenClaw Direct Mode existence proof and the Amazon Q enterprise-scale failure case. **v20** is the *Edge Twin Data-Governance Pass*: adds the "Does the Edge Twin fork your data?" sidebar (the first question every CIO asks), and pairs it with the Workflow Data Manifest in `references/rewrite-playbook.md` Step 3 and the CIO Edge Twin Diagnostic at `templates/cio-edge-twin-diagnostic.md`. See also `references/edge-twin-data-governance.md`.
+
+For any organization with real scale, transformation cannot happen in the core. The core is optimized to preserve the current operating model. The Edge Twin is built to replace it one workflow at a time.
+
+## Why the Core Kills Innovation
+
+Christensen's innovator's dilemma describes how incumbents fail to cannibalize themselves. That framing assumes the threat comes from below, cheaper products stealing the low end. What AI introduces is different: the threat comes from the *edge* of the organization itself, a digital twin that gradually outperforms the mothership not by being cheaper, but by being faster, better-informed, and structurally unconstrained.
+
+History strongly supports this pattern. Disruptive innovation rarely succeeds inside the core. The mothership optimizes for margin defense, risk mitigation, institutional preservation. Every "transform the core" attempt runs into legacy systems, regulatory constraints, institutional inertia, incentive structures that punish disruption, and middle management defending territory. As John Hagel and John Seely Brown note: big companies are optimized for two heuristics, Predictability and Efficiency. Both are antithetical to disruptive innovation.
+
+If you try to apply REWRITE inside the mothership, it will fail. The framework can be right and still fail because the host organism rejects it. The traditional line is that you're trying to rebuild the airplane while flying it. **A more accurate visual: you are climbing into the jet engine turbine to fix it while the plane is in the air.** The outcome is not pretty.
+
+### A Necessary Caveat
+
+Not every AI deployment failure is the immune system. Some fail because the technology isn't ready, some because economics don't pencil, some because the use case was wrong. The immune system is not the only explanation. But it is the *dominant* one in our experience: technology is ready enough, economics work for the right workflows, and organizational resistance kills the initiative before it can prove itself.
+
+## Evidence: Edge Deployment Works
+
+- **Nespresso (1976 → 1986 → today, $7B+ business).** Invented inside Nestlé in 1976. Floundered for a decade. Spun out in 1986. Today one of Nestlé's highest-margin businesses. Why? Because it was never forced to fit inside the core. The edge venture grew until it became a center of gravity in its own right.
+- **Cognition Labs (Devin).** Clean-room AI-native venture. **73× ARR growth in 9 months. Team of 14 people. Enterprise adoption by Goldman Sachs and Citi. Total net burn under $20M.** The receipts for the Intelligence Density component of Value Moat.
+- **Klarna.** AI customer service agent replacing the work of 700 full-time agents. Deployment cost $2–3M. Profit improvement $40M.
+- **Block (March 2026, $50B+ public company).** 4,000 layoffs (~40% of workforce) followed by Dorsey & Botha's *"From Hierarchy to Intelligence"* manifesto. Three-role replacement structure: ICs / DRIs / Player-Coaches. **The cleanest live test of the Coasean-collapse thesis at corporate scale.** Anti-pattern read alongside it: Block has no GOVERN/ASSURE equivalent, see `drive-engine.md` for the canonical DRIVE-without-SHAPE warning.
+- **Haier (RenDanHeYi, since 2012).** 80,000+ employees, thousands of micro-enterprises, no traditional management layer, 23% annual growth sustained for a decade. Pre-AI existence proof that the post-hierarchy firm scales. ZeroDX (2025) is now integrating AI underneath the architecture.
+
+The pattern is identical: build the AI-native alternative, prove it outperforms, let natural selection do its work.
+
+## Three-Phase Studio Evolution (the Empirical Foundation)
+
+The venture studio sector has already gone through what we are prescribing for all organizations.
+
+- **Phase 1, Traditional (late 2000s–2022).** Labor-intensive, sequential. ~1 project per person-year. U+ Digital Ventures: 120 people, $10M+ revenue.
+- **Phase 2, AI-Assisted (2023–2024).** LLMs as productivity multipliers. 20–40% efficiency gains. Productivity multiplication of human-centric workflows is competitively insufficient. *Where most enterprise AI stalls today.*
+- **Phase 3, Agentic AI-Native (2024–present).** Autonomous systems executing multi-step tasks. Throughput decoupled from team size.
+
+| Metric | Traditional | Agentic AI-Native |
+|---|---|---|
+| Team size | 120 people | 14 people (−88%) |
+| Annual ventures | ~12 | 75+ in first month |
+| Throughput per person | ~1 project / year | 40+ projects / year |
+| Studio IRR | 25–40% | 50–70%+ |
+| Cost per venture (to validation) | $500K–$2M | $50K–$200K |
+
+### Two Reference Paths
+
+- **Path A: Radical Transformation, FifthRow.** Dissolved a successful 120-person business and rebuilt it as a 14-person AI-native platform in six months. First-mover advantage of 6–12 months. **Maps to Edge Mode.**
+- **Path B: Evolutionary Repositioning, Board of Innovation.** Repositioning from "design thinking consultancy" to "AI Transformation Studio" over 2023–2025. 115× faster ideation for Walmart (5 days → 1 hour). 9× ROI on a CPG agentic deployment. 3× faster idea-to-market for Nestlé. **Maps to Direct Mode.**
+
+Both converge on the same destination. The difference is the migration path.
+
+## The Solution: Build an Edge Venture (the Edge Twin)
+
+The edge venture is a structurally separate, AI-first replica of a core business function or unit, built at the organizational edge, executing the same economic purpose as the original, but through an Intelligence Stack architecture rather than a human-centric workflow architecture. We call it an **AI-native Edge Twin**.
+
+**One-sentence definition.** An **Edge Twin** is a board-mandated, CEO-sponsored parallel business unit, 3–5 people plus an agent cluster, that rebuilds specific mothership workflows from scratch using the Intelligence Stack, proves they outperform the original, and then replaces them. *It is not an innovation lab or a skunkworks.* It is a functioning operation producing real output for real customers using AI-native architecture, the prototype of what the whole company becomes.
+
+### The Peter Principle for AI Agents (v13): Why the Edge Twin Exists at All
+
+Martin Varsavsky, 2026: *"Every AI system will be pushed to the limits of its competence. Organizations will delegate as much as they can to the AI. They will only know how far was too far by going too far and recovering."*
+
+That recovery loop **is the actual learning mechanism** for any AI deployment, and it is exactly the loop the core organization cannot afford to run on customers of record. Theory does not produce the autonomy ceiling. **Recovery from real incidents does.**
+
+This reframes the Edge Twin from "a place to build the AI-native organization" (v10's framing) into "the only safe place to discover the autonomy ceiling experimentally." The mothership inherits only what has already been bounded by lived failure.
+
+**Precondition.** The Edge Twin must have **Granular Rollback** (the third of the Four Pillars) in place before it begins discovering the ceiling. Push-to-limits-then-recover is not a contingency. It IS the learning mechanism.
+
+### Cross-Firm Operation (v13)
+
+Once the Edge Twin is live, it will eventually transact with other firms' agents. **The architecture for that lives in Chapter 3's Cross-Organizational Accountability stack**, policy-controlled API surface for external agents, HIDO metadata travelling with the data, codesigned liability framework. See `shape-form.md` (E, Ecosystem Trust). Build the cross-firm stack before the first agent-to-agent transaction, not after.
+
+### Does the Edge Twin Fork Your Data? (v20)
+
+This is the first question every CIO asks. The wrong answer kills the project before it starts.
+
+**No.** The Edge Twin does not copy the enterprise data estate, and it does not get super-user access to production databases. It gets workflow-scoped, governed API access to the specific systems one migrated workflow needs, with the following primitives in place from Day 1:
+
+- **Workflow-scoped, not estate-wide.** An Edge Twin running order-exception handling sees order status, inventory, shipping, contract terms, and resolution history. It never sees the HR system or the general ledger. Scope is set by the Workflow Data Manifest (Step 3 EXTRACT), not by IT defaults.
+- **Read and write separated.** Different credentials, different scopes. Writes pass through approval thresholds and soft-delete windows. The Permission Envelope holds.
+- **Every call logged on a correlation ID.** SENSE -> INTERPRET -> DECIDE -> ORCHESTRATE -> outcome traceable end to end. This is Pillar 2 (Searchable Logs with Correlation IDs).
+- **Credentials short-lived and revocable.** Not an employee's credentials, not an admin token, not a shared API key. The twin gets its own scoped workload identity with rotation and immediate revocation.
+- **Every object the twin touches still answers the HIDO Six Questions.** The workflow manifest governs the surface; HIDO governs each object.
+
+**Operational systems remain the source of truth.** If the Edge Twin and the ERP disagree, the ERP wins. The twin is the reasoning, simulation, and orchestration layer. It is not a second system of record, and it is never allowed to become one early.
+
+**Access is not training.** By default, the twin retrieves governed data at runtime and learns from workflow traces, human corrections, outcomes, and synthetic edge cases, not from possession of the data estate. Any training or fine-tuning happens only on approved, curated, de-identified datasets. Executives confuse access with training. They are different contracts. Pin both in writing with the vendor: retention, training rights, deletion rights, audit rights, model isolation.
+
+**The Edge Twin earns its data the way a new hire does, by doing the work, not by being handed the vault.**
+
+See `references/edge-twin-data-governance.md` for the full principles and the CIO-grade walkthrough.
+
+## The Five Build Steps
+
+1. **Spawn at the edge.** Partner with an AI-native firm, a builder, not a consultancy. Reports directly to the CEO. No one else. Board-mandated insulation. 3–5 humans + agent cluster. Real business problem.
+2. **Fund it right.** CEO's budget or board allocation, **never a division budget** (immune system attack vector). Shared upside with the edge team, performance bonuses, equity-like upside, revenue share on proven savings. Salaried teams optimize for survival; teams with skin optimize for results.
+3. **Run on REWRITE from Day 1.** Born without organizational drag. AI elevated to executive layer. Work designed around tasks, not legacy roles. Stack architecture native. Governance agents from day one, not bolted on.
+4. **Migrate workflows easiest first.** Low-risk first (customer routing, pricing, inventory). Then medium (procurement, scheduling, QC). Then higher-judgment (resource allocation, market entry/exit). One workflow at a time. Prove. Move to the next.
+5. **The edge becomes the center of gravity.** As the twin grows, it absorbs more of the mothership. The mothership gradually becomes the legacy system. **This is metamorphosis, not transformation.**
+
+## Failure Modes and Defenses
+
+Three primary failures:
+
+- **The immune system kills the venture.** Defense: structural insulation, CEO sponsorship, no division-level reporting line.
+- **Costs spiral before proof.** Defense: ruthless sequencing, one workflow at a time.
+- **CEO sponsorship lapses.** Defense: speed to undeniable results, board visibility, monthly readouts.
+
+The edge model works because it avoids the dynamics that kill core transformation. The mothership keeps operating, no existential threat to incumbents during transition. Each migrated workflow proves the model. The edge venture operates at machine tempo with recursive self-improvement running. **It automatically outperforms the mothership over time.**
+
+## Who Needs This and Where to Start
+
+- **≤50 employees.** The company IS the edge. No immune system strong enough to kill transformation. Skip this chapter, apply REWRITE in place via Direct Mode.
+- **>50 employees.** Edge deployment is mandatory. This is where Dunbar's number kicks in, layers form, coordination costs emerge, the immune system has enough mass to fight back. A 500-person company has a moderate immune response. A 50,000-person company will kill transformation initiatives with the efficiency of a trained immune system.
+
+**Rule:** *If your CEO can't name every employee and describe their workflow, build at the edge.*
+
+**The CEO's first question:** *"Which business unit or function do we spawn at the edge first?"* The one with the highest ratio of coordination work to judgment work. That's where agents create the most leverage and where the digital twin will outperform the mothership fastest.
+
+## What Comes Next
+
+After the first edge venture is running, the **Continuous Kill Switch** feeds the pipeline. Detection → spawn → migrate → deprecate → repeat. Edge deployment is not a one-time event. It is a permanent migration engine, fed by continuous self-disruption detection.
+
+## Mission-Driven Adaptation (Government, Non-Profits, Public Sector)
+
+Mission-driven organizations face the same AI-native transition as companies, but with stronger public obligations, slower procurement, and legal immune systems.
+
+### Five Structural Differences from Private-Sector Transformation
+
+1. **The immune system is law.** Civil service protections, union agreements, procurement mandates. Antibodies are codified.
+2. **The "customer" can't switch providers.** Citizens are captive. No competitive pressure, until political pressure replaces it.
+3. **Regulatory compliance is the product.** In the private sector, compliance is a constraint. In government, compliance *is* the work.
+4. **Procurement was designed to prevent corruption, not enable speed.** Average federal IT procurement: 18+ months. By the time the contract is signed, the technology is obsolete.
+5. **Every government entity is in edge mode.** Even a 20-person agency operates inside a larger bureaucratic immune system. **There is no Direct Mode in government.**
+
+### The Citizen Demand Forcing Function
+
+Once people experience AI-native private-sector services, instant, personalized, 24/7, they refuse to accept 6-week permit processing and hold music. The proof is live:
+
+- **Singapore (Ask Jamie):** 15M+ queries across 80+ agencies, 50%+ resolved without human intervention. Pair AI tool: 60,000 government users, 46% admin time saved.
+- **UK Police (Bobbi):** 82–90% of citizen queries resolved by AI agent without human escalation. Live since November 2025.
+- **US municipalities:** 22× faster permit processing at 83% less cost in early-adopter cities.
+- **UAE:** 97% AI tool adoption across government entities. 108 services automated. AI HR assistant serving 50,000+ employees.
+
+The political pressure comes from below, not above. The mayor who can't match private-sector service quality loses the next election.
+
+### The Anti-Case Study: Headcount Without Workflow Redesign
+
+A recent large-scale US government workforce reduction cut 271,000 federal positions, 9% of the workforce, the largest peacetime reduction on record. Leaders claimed over $100B in savings. The Cato Institute found no noticeable effect on spending trajectory. Independent nonpartisan analysis estimated the initiative actually *increased* net costs. The program was abandoned within a year.
+
+**What went wrong.** The initiative attacked people without transforming the system. Headcount reduction without workflow redesign produces zero structural improvement. They eliminated positions but didn't redesign the workflows those positions served. The remaining staff absorbed the coordination burden. Backlogs grew. Service degraded.
+
+**The lesson.** *You cannot cut your way to transformation. Build the AI-native alternative and migrate to it.*
+
+### The Sovereignty Imperative
+
+Sovereign AI capability, owning the inference, the orchestration logic, and the fine-tuning data, becomes a national security imperative for any government deploying agents at scale. Cognitive captivity at the firm level is bad. At the nation level, it is catastrophic.
+
+Every government building AI capacity must answer: *if our model provider raises prices, changes terms, or comes under foreign jurisdiction, what happens to our citizen services?*
+
+The architecture is the same as the private-sector Edge Twin model. Build at the edge. Prove. Migrate. The difference is the political theatre and the procurement timeline. Both are solvable with sponsored mandate from the executive layer.

--- a/skills/building-an-exo/references/edge-twin-data-governance.md
+++ b/skills/building-an-exo/references/edge-twin-data-governance.md
@@ -1,0 +1,131 @@
+# Edge Twin Data Governance: The CIO's First Objection, Answered
+
+> Source: *The Organizational Singularity*, OS Outline v20, Chapter 8, Edge Deployment, and Appendix F, The CIO Edge Twin Diagnostic. Salim Ismail with contributors, May 2026. v20 is the *Edge Twin Data-Governance Pass*: the first question every CIO asks, the answer the book commits to, and the operational primitives that make the answer hold.
+
+## Why This Reference Exists
+
+When you propose an Edge Twin, the CIO and CISO do not ask *"can it work?"* They ask *"can I govern it, audit it, secure it, reverse it, and explain it?"* Every objection is legitimate. The first one, every time, is: **does the Edge Twin fork our data?**
+
+This reference is the load-bearing answer. It pairs with:
+
+- The Workflow Data Manifest (REWRITE Step 3 EXTRACT exit criterion). See `references/rewrite-playbook.md` and `templates/workflow-data-manifest-template.md`.
+- The HIDO Six Questions (per data object). See `references/intelligence-stack.md` and `templates/hido-six-questions.md`.
+- The CIO Edge Twin Diagnostic (Appendix F readiness gate). See `templates/cio-edge-twin-diagnostic.md`.
+
+## The One-Sentence Answer
+
+**No.** The Edge Twin does not copy the enterprise data estate. It gets workflow-scoped, governed API access to the specific systems one migrated workflow needs, with read and write separated, every call logged on a correlation ID, and credentials short-lived and revocable. Operational systems remain the source of truth. If the Edge Twin and the ERP disagree, the ERP wins. The twin is the reasoning and orchestration layer, not a second system of record.
+
+## The Six Governance Primitives
+
+### 1. Workflow-Scoped Access, Not Estate-Wide
+
+Scope is set by the **Workflow Data Manifest** (REWRITE Step 3), not by IT defaults. The manifest enumerates every source the workflow touches, the reason it needs each one, read or write, the sensitivity tier, retention in the twin's memory, and the named data owner who approves access.
+
+The binary rule. *If you cannot state why a workflow needs a field, the Edge Twin does not get it.*
+
+A worked example. An Edge Twin running order-exception handling sees order status, inventory, shipping, contract terms, and resolution history. It does not see the HR system. It does not see the general ledger. It does not see anything that is not on the manifest.
+
+### 2. Read and Write Separated
+
+Different credentials. Different scopes. Writes pass through approval thresholds and soft-delete windows. The Permission Envelope enforces both. The PocketOS lesson institutionalized: destructive endpoints are a separate Autonomy Tier with mandatory approval, soft-delete windows on every destructive operation, backups in a different blast radius than the data they protect.
+
+### 3. Correlation-ID Logging End to End
+
+Every call is logged. Every decision traceable. SENSE -> INTERPRET -> DECIDE -> ORCHESTRATE -> outcome chained on a single correlation ID. This is Pillar 2 of GOVERN/ASSURE (Searchable Logs with Correlation IDs). Logs are immutable, hashed, and cryptographically signed.
+
+The CISO's test: *"can I see exactly what the twin accessed, why, and what it did next?"* If the answer requires reconstructing the run, the architecture is not deployed yet.
+
+### 4. Short-Lived, Revocable Credentials
+
+The twin gets its own **scoped workload identity**. Not an employee's credentials. Not an admin token. Not a shared API key. Credentials are short-lived, rotated automatically, and immediately revocable. Per-action logging, per-action authorization. Approval thresholds on destructive endpoints. The Searchable Logs pillar makes every credential use auditable.
+
+### 5. Operational Systems Are the Source of Truth
+
+**If the Edge Twin and the ERP disagree, the ERP wins.** Every time. Without exception. The twin is the reasoning, simulation, and orchestration layer. It is not a second system of record, and it is never allowed to become one early.
+
+This rule lives in the Edge Twin charter, signed by the CEO and the CIO before funding. Without it, the twin drifts into shadow-IT territory the moment the first reconciliation disagreement appears.
+
+### 6. Per-Object HIDO Governance
+
+Each object the twin touches still answers the **HIDO Six Questions**: what is it, who says so, how can it be used, what are the legal terms, what happens if it is wrong, how is a dispute resolved. Carried as immutable, hashed, signed metadata bound to the object.
+
+The Manifest governs the workflow's data surface. HIDO governs each object inside the surface. Both are required.
+
+## Access Is Not Training
+
+This is the single most common executive confusion. Access and training are different contracts.
+
+**Default posture.** The twin retrieves governed data at runtime. It learns from workflow traces, human corrections, outcomes, and synthetic edge cases. It does not learn from possession of the data estate.
+
+**Training and fine-tuning** happen only on approved, curated, de-identified datasets, under a separate vendor contract.
+
+**Pin both in writing** with the vendor:
+
+- Retention (how long the vendor holds data and logs)
+- Training rights (whether the vendor may use customer data to train any model)
+- Deletion rights (timeline, completeness, audit)
+- Audit rights (the customer's ability to inspect what the vendor holds)
+- Model isolation (separation between this customer's model state and any shared model)
+
+If these five are not in the contract, the data answer is *yes, the twin trains on your data*, regardless of the marketing copy.
+
+## The Earned-Data Principle
+
+**The Edge Twin earns its data the way a new hire does, by doing the work, not by being handed the vault.**
+
+A new hire on Day 1 gets a laptop, an email account, and access to the specific systems they need for their job. They do not get root on the file server. They do not get the customer database. They do not get HR records. As they take on more responsibility, their access expands. The same discipline applies to the twin.
+
+Day 1: one workflow, one data manifest, one scoped credential set, one correlation-ID stream.
+Day 60: the twin has earned access to the next workflow by proving it on the first.
+Day 180: a second workflow is on parallel run. Manifests, credentials, and logs are all separate and additive.
+
+This is the operational shape of the *easiest first* rule from Edge Deployment (`references/edge-deployment.md`).
+
+## Mapping to GOVERN/ASSURE
+
+The data-governance primitives are not separate from the Four Pillars. They are *how* the Pillars hold for data.
+
+| Data primitive | Pillar that enforces it |
+|---|---|
+| Workflow-scoped access | Trusted Evals (workflow-specific eval suite) + Searchable Logs (audit trail) |
+| Read/write separation | Granular Rollback (writes are recoverable per scope) + Human Review Queue (writes touching money/legal/CoR route to a named human) |
+| Correlation-ID logging | Searchable Logs (the pillar by name) |
+| Short-lived, revocable credentials | Searchable Logs (per-action logging) + Granular Rollback (credential revocation is the rollback path) |
+| ERP-wins source of truth | Trusted Evals (twin output evaluated against operational system on every cycle) |
+| HIDO metadata per object | Underpins all four pillars; metadata travels with the data |
+
+If a pillar is below 3/5 for this workflow, the data primitive it backs cannot be relied on. That is the gate.
+
+## Standards Cross-Reference
+
+The data-governance primitives operationalize, rather than restate, the following:
+
+- **NIST AI Risk Management Framework (2023)** for risk across design, development, use, and evaluation
+- **OWASP Top 10 for LLM Applications** for the failure modes (prompt injection, sensitive-information disclosure, insecure output handling, excessive agency)
+- **CSA AI Controls Matrix (July 2025)** for the 243 control objectives across 18 domains
+
+See `references/four-pillars-standards-mapping.md` for the per-control crosswalk.
+
+## The Failure Mode
+
+Treating data governance as Phase-2 polish. The twin starts with broad access *"to get something working"* and the manifest is promised for *"the next sprint."* Within 60 days the twin is a second system of record, the ERP reconciliation is contested, the CISO is in the room, and the Edge Twin is killed or quarantined.
+
+The defense. The Workflow Data Manifest is a Step 3 EXTRACT exit criterion, not a Step 5 nice-to-have. The CIO Edge Twin Diagnostic runs before funding, not after. The first workflow is a workflow the manifest can describe completely on one page.
+
+## The CIO Sign-Off Checklist
+
+Before the Edge Twin is funded, the CIO confirms in writing:
+
+- [ ] No fork of the enterprise data estate
+- [ ] Workflow Data Manifest signed for the first workflow
+- [ ] Workflow-scoped API access only (no super-user, no admin tokens)
+- [ ] Read and write credentials separated, with write approval thresholds
+- [ ] Correlation-ID logging operational end to end
+- [ ] Scoped workload identity provisioned, short-lived, revocable
+- [ ] Operational systems remain source of truth (ERP wins ties)
+- [ ] HIDO metadata in place on every data object the workflow touches
+- [ ] Access-vs-training distinction pinned in vendor contract (retention, training rights, deletion rights, audit rights, model isolation)
+- [ ] Appendix F (CIO Edge Twin Diagnostic) scored: no red on Q5, Q6, Q7, or Q8
+
+If any line is unsigned, the Edge Twin is not funded.

--- a/skills/building-an-exo/references/exo30-architecture.md
+++ b/skills/building-an-exo/references/exo30-architecture.md
@@ -1,0 +1,131 @@
+# ExO 3.0: The Destination Architecture
+
+> Source: *The Organizational Singularity*, OS Outline v15, Chapter 3, ExO 3.0: The Destination Architecture. Salim Ismail with contributors, May 2026. v13 was the "Accountability & Auditability pass" over v10, adding the Four Pillars of GOVERN/ASSURE, Silent Drift, Cross-Organizational Accountability, the HIDO Six-Question Diagnostic, and the Peter Principle for AI Agents as first-class concepts. **v15 is the Social Capital Primer Integration pass**, adding the Intelligence Stack ↔ 5-Layer Agent Stack Crosswalk, the Amazon Q enterprise-scale failure sidebar, the Steinberger / OpenClaw Direct Mode existence proof and 36.3% solo-founded-startup datum, plus Chapter 11 receipts for tokens as cost of goods sold (SemiAnalysis) and per-outcome pricing (Salesforce Headless 360, April 15 2026). See `references/social-capital-crosswalk.md` and `references/v15-deltas.md` for verbatim source text.
+
+ExO 3.0 names the destination of the AI-native firm. It supersedes ExO 1.0's SCALE/IDEAS framing because the internal/external distinction that SCALE/IDEAS rested on is now obsolete: agents move work across the firm boundary at machine speed.
+
+## What's Preserved, What's Replaced
+
+| ExO 1.0 (2014) | ExO 3.0 (2026) |
+|---|---|
+| MTP (poster, north star) | MTP-as-protocol (three machine-readable layers) |
+| SCALE (5 external attributes) | DRIVE (5 intelligence-engine components) |
+| IDEAS (5 internal attributes) | SHAPE (5 organizational-form components) |
+
+ExO 1.0 introduced the canvas tradition past the firm boundary. ExO 3.0 inherits that lineage and updates it for the agentic era, replacing static description with a living operating model.
+
+## Canvas Lineage
+
+This is not the first attempt to compress a business model onto a single frame.
+
+- **Porter's Value Chain (1985)** decomposed the firm into primary and support activities.
+- **Osterwalder's Business Model Canvas (2010)** gave a generation of founders nine boxes (value props, segments, channels, revenue, cost, partners, resources, activities, relationships).
+- **Maurya's Lean Canvas (2012)** tightened it for startups.
+- **Wardley Maps (2015)** added evolution and positional awareness.
+- **ExO 1.0 (2014)** introduced MTP + SCALE + IDEAS, extending the canvas tradition past the firm boundary.
+- **ExO 3.0 (2026)** replaces static description with a living operating model: MTP as protocol, DRIVE as intelligence engine, SHAPE as organizational form, Intelligence Stack as operating core.
+
+## The Ten Characteristics
+
+ExO 3.0 = MTP + DRIVE (5) + SHAPE (5). Each component scoreable 1–5; max 50 across DRIVE and SHAPE combined. MTP is gating, not scored on the same scale.
+
+### MTP: Massive Transformative Purpose
+
+Now encoded as machine-readable governance with three layers:
+
+- **Constraint Layer**, what agents are categorically forbidden from doing. Hard constraints, not aspirational values.
+- **Decision Layer**, weighted priorities agents use when facing tradeoffs (speed vs. quality, cost vs. impact).
+- **Identity Layer**, the cultural cohesion mechanism that replaces "the office."
+
+The MTP is not a poster. It is a protocol.
+
+**Two litmus tests:**
+
+1. *Could an AI agent, given only your MTP protocol, make a decision your leadership team would endorse?* If no, your MTP is a poster, not a protocol.
+2. *Could that agent, given only your MTP, decide what NOT to build?* When execution is nearly free, the feature factory is the dominant failure mode.
+
+### DRIVE: The Intelligence Engine (what makes you fast and smart)
+
+- **D, Decision Architecture** (Bezos two-way/one-way doors, Taleb barbell, Hart incomplete contracts)
+- **R, Recursive Learning** (Senge, McGrath, RLHF patterns)
+- **I, Intelligence Stack** (the operating core; everything else plugs into it)
+- **V, Value Moat** (proprietary data, network effects, intelligence density, reconfiguration speed, curatorial judgment)
+- **E, Elastic Agency** (Capability Registry, Graduated Authority, Decision Boundary)
+
+See `drive-engine.md` for full component definitions and scoring.
+
+### SHAPE: The Organizational Form (what keeps you right and resilient)
+
+- **S, Safe Autonomy** (Fiduciary Wedge, compliance-as-code, kill switches, audit trails, agent-to-agent oversight)
+- **H, Human Architecture** (where human cognition is irreplaceable; Middle 60% problem; missing junior loop; bifurcation risk)
+- **A, Adaptive Architecture** (modularity + antifragility; pod-based intelligence networks)
+- **P, Purpose Control** (MTP as three-layer protocol; identity binding past compensation)
+- **E, Ecosystem Trust** (cryptographic identity, verifiable credentials, mechanism design)
+
+See `shape-form.md` for full component definitions and scoring.
+
+**The crossing rule:** *DRIVE without SHAPE crashes. SHAPE without DRIVE stalls. You need both.*
+
+## The Five Design Conditions
+
+Five conditions must hold for ExO 3.0 to function. Treat as principled anchors, not KPIs:
+
+1. **AI-Centric Workflow Architecture.** Coordination flows through AI-first processes. Humans validate, don't route.
+2. **Recursive Improvement Infrastructure.** Agents continuously refine their workflows. The Stack learns, not just executes.
+3. **Model Sovereignty and Governed Autonomy.** No single-vendor dependency. GOVERN/ASSURE live from Day 1.
+4. **Intelligence Density at Every Layer.** Strategy, management, and execution all operate with AI support. No layer in information darkness.
+5. **Human Flourishing as a Binding Constraint.** Middle 60% transition planned and funded. Dignity is a design parameter, not an afterthought.
+
+If any condition is violated, the architecture fails, through technology debt, regulatory backlash, talent flight, or political resistance.
+
+**v13 makes these conditions a binding Step-1 exit gate**, not merely aspirational principles. If any one of the five is violated, the Destination Architecture is incomplete and REWRITE Step 1 is not done. See `rewrite-playbook.md` Step 1 for the exit-criteria detail.
+
+## The Three Compounding Loops
+
+The ten characteristics are not a checklist. They compound through three reinforcing loops. v13 makes the inter-characteristic edges explicit:
+
+- **Intelligence Loop (D → I → R → V):** Better decisions feed the Stack. The Stack produces richer data. Data feeds learning. Learning widens the moat. The moat funds investment in better decisions.
+- **Trust Loop (E-Trust → E-Agency → V):** Trust attracts contributors. Contributors generate intelligence. Intelligence strengthens the moat. The moat attracts more contributors.
+- **Governance Loop (S → A → R):** Stronger Safe Autonomy enables more delegation. More delegation surfaces more edge cases. Edge cases feed Recursive Learning. Better learning earns more trust to delegate further.
+
+The Intelligence Loop creates the advantage. The Trust Loop scales it. The Governance Loop ensures it doesn't collapse under its own velocity. **Optimizing one loop at another's expense is the dominant ExO 3.0 failure mode.**
+
+## The Miura-Ko Ladder (L0–L5): The AI-Pilled Ladder
+
+The asteroid is binary; the response is not. Ann Miura-Ko (Floodgate, April 2026), borrowing the SAE levels of vehicle autonomy, proposes a six-level diagnostic gradient sitting underneath this book's binary Dabbling Test. Score across four questions: *what can AI see, what can AI do, who can extend the system, how has the org changed.*
+
+- **L0, AI as Theater.** Announcements, no adoption. Same chart, same hiring plan, same managers as routers.
+- **L1, Personal Productivity.** Each user reinvents independently. Power users are heroes; workflows leave when they leave.
+- **L2, Team Workflow.** Function-specific stacks. AI-enhanced silos calling themselves AI-native.
+- **L3, Organizational Infrastructure.** **Threshold where the architecture in this book starts to compound.** Cross-functional agents act on systems of record. Hard test: can an agent answer, across systems, *what shipped, who asked for it, what broke, and what to do next*, without convening a meeting?
+- **L4, Compounding Operating System.** **Where Value Moats form.** System maintains its own context. Agents update agents. Non-engineers ship production internal tools. Compensation tied to AI proficiency. Customer signal-to-ship in hours.
+- **L5, Virtually Self-Driving Organization.** **Destination state. Does not yet exist.** System notices something important without being asked, synthesizes, decides, acts within delegated authority, escalates on uncertainty, updates shared memory. Humans govern strategy, taste, risk, values, exceptions.
+
+### Readiness Score ↔ Miura-Ko cross-reference
+
+| REWRITE Readiness Score | Miura-Ko Level | What it means |
+|---|---|---|
+| Below 33 | L0–L1 | Theater or personal productivity. Fails Dabbling Test. |
+| 33–55 | L2 | Team workflow. AI-enhanced silos. |
+| 56–80 | L3 emerging, L4 forming | Compounding begins. |
+| Not measurable yet | L5 | Generative noticing. Post-2031. |
+
+**The trust-the-ladder rule.** *"If your score and your level diverge sharply, trust the ladder. Capacity that hasn't been operationalized doesn't compound. A high Readiness Score with a low Miura-Ko level is the signature of a firm that has bought the architecture but hasn't deployed it, the most expensive failure mode in the framework."*
+
+## Proof Points: Block, Haier, Cognition Labs
+
+Three case examples anchor the v13 architecture across scale and sector:
+
+- **Block (Dorsey & Botha, March 2026)**, $50B+ public company, **4,000 employees laid off** (~40% of workforce) in Feb 2026, followed by Dorsey's *"From Hierarchy to Intelligence"* manifesto. Replaced traditional management with a **three-role structure**: Individual Contributors (build capabilities), Directly Responsible Individuals/DRIs (own cross-cutting problems for fixed periods), Player-Coaches (build + people development). No permanent middle management. Companies need both a continuously updated **"world model"** of operations (Stack's INTERPRET + LEARN) and a strong **"customer signal"** (SENSE layer). Block executed in one quarter what consultants describe as a five-year roadmap. **The cleanest live test of the Coasean-collapse thesis at corporate scale**, and the canonical **DRIVE-without-SHAPE** warning: Block's architecture has no GOVERN/ASSURE equivalent, no Fiduciary Wedge mapping, no compliance-as-code, no kill-switch mechanisms. For a payments company in regulated financial services, this is not a minor oversight.
+
+- **Haier (RenDanHeYi, since 2012)**, **80,000+ employees**, broken into thousands of micro-enterprises functioning as internal startups with direct customer accountability, no traditional management layer. **23% annual growth sustained over a decade.** Pre-AI proof that hierarchy is not a law of physics; it is a coordination technology, and alternatives work at massive scale. Haier is now integrating AI into RenDanHeYi via **ZeroDX (2025)**, essentially building the Intelligence Stack underneath an organizational architecture that was already designed to receive it. **The strongest existence proof that the post-hierarchy firm scales.** AI is the mechanism that makes it the default rather than the exception.
+
+- **Cognition Labs (Devin)**, Clean-room AI-native venture. **73× ARR growth in 9 months.** Enterprise adoption by **Goldman Sachs and Citi.** Total net burn **under $20M.** Team of **14 people.** The receipts for the Intelligence Density component of Value Moat.
+
+## What the Founder Should Remember First
+
+If you remember one thing: **the Intelligence Stack is the operating core.** The other nine characteristics define the context in which the Stack operates. If you build one thing first, build the Stack.
+
+If you remember two things: **DRIVE without SHAPE crashes. SHAPE without DRIVE stalls.**
+
+If you remember three things: **Destination, Operating System, Playbook.** ExO 3.0, the Intelligence Stack, REWRITE. The rest of the framework is in service of those three.

--- a/skills/building-an-exo/references/four-pillars-standards-mapping.md
+++ b/skills/building-an-exo/references/four-pillars-standards-mapping.md
@@ -1,0 +1,106 @@
+# Four Pillars of GOVERN/ASSURE: Standards Mapping
+
+> Source: *The Organizational Singularity*, OS Outline v20, Chapter 4 (footnote on standards mapping). Salim Ismail with contributors, May 2026. v20 adds the explicit mapping of the Four Pillars to NIST, OWASP, and CSA frameworks. The Pillars *operationalize* these frameworks. They do not restate them.
+
+## The Position
+
+CISOs, auditors, and boards already speak the language of NIST, OWASP, and the Cloud Security Alliance. The Four Pillars are the production implementation of what those frameworks specify in the abstract.
+
+When the conversation starts at *"how does this map to NIST AI RMF?"* the answer is not *"it doesn't, because we use the Four Pillars."* The answer is *"each Pillar is the production primitive that operationalizes a specific set of NIST controls, OWASP failure modes, and CSA control objectives. Here is the mapping."*
+
+## The Three Frameworks Anchored
+
+### NIST AI Risk Management Framework (2023)
+
+- Source: National Institute of Standards and Technology
+- URL: `https://www.nist.gov/itl/ai-risk-management-framework`
+- Scope: Voluntary framework governing risk across the AI lifecycle (design, development, use, evaluation).
+- Why it matters: NIST AI RMF is the default reference framework for US federal agencies and the de facto vocabulary used by enterprise risk committees.
+
+### OWASP Top 10 for LLM Applications
+
+- Source: OWASP Foundation
+- URL: `https://owasp.org/www-project-top-10-for-large-language-model-applications/`
+- Scope: The ten most critical failure modes for LLM-backed applications, including prompt injection, sensitive-information disclosure, insecure output handling, and excessive agency.
+- Why it matters: OWASP names the *failures the Pillars catch*. When the security team asks *"how do you handle prompt injection?"* the OWASP vocabulary is the bridge.
+
+### Cloud Security Alliance AI Controls Matrix (AICM)
+
+- Source: Cloud Security Alliance
+- URL: `https://cloudsecurityalliance.org/artifacts/ai-controls-matrix`
+- Scope: 243 control objectives across 18 domains (July 2025 release).
+- Why it matters: AICM is the controls superset. Auditors map it directly to ISO 27001, SOC 2, and HIPAA controls inventories. The Pillars implement, rather than restate, the relevant AICM controls.
+
+## Per-Pillar Mapping
+
+### Pillar 1: Trusted Evals
+
+**Operationalizes.**
+
+- NIST AI RMF: *Measure* function (testing, evaluation, validation, monitoring across the lifecycle).
+- OWASP LLM Top 10: catches drift that surfaces as model misbehavior, hallucination, and quality degradation.
+- CSA AICM: control domains covering model validation, performance monitoring, and continuous testing.
+
+**What it does in production.** Every agent runs continuously against a known test set. Drift below a quantified threshold (accuracy floor, override-rate ceiling) triggers retraining or rollback automatically. An agent without an eval suite is a demo, not a production agent.
+
+### Pillar 2: Searchable Logs with Correlation IDs
+
+**Operationalizes.**
+
+- NIST AI RMF: *Manage* function (transparency, accountability, traceability of decisions and outcomes).
+- OWASP LLM Top 10: insecure output handling (LLM07) and sensitive-information disclosure (LLM06) detection through log inspection.
+- CSA AICM: logging, audit trail, and forensic recovery control objectives across multiple domains.
+
+**What it does in production.** Every decision is recoverable from the audit trail alone. SENSE -> INTERPRET -> DECIDE -> ORCHESTRATE -> outcome chained on a single correlation ID. Logs are immutable, hashed, and cryptographically signed. Humans can reconstruct, debug, and explain any outcome without reproducing the run.
+
+### Pillar 3: Granular Rollback
+
+**Operationalizes.**
+
+- NIST AI RMF: *Manage* function (incident response, recovery, model lifecycle versioning).
+- OWASP LLM Top 10: response to insecure output (LLM07), excessive agency (LLM08), and overreliance (LLM09).
+- CSA AICM: configuration management, version control, and recovery control objectives.
+
+**What it does in production.** Any single agent revertible to last week's prompt, last month's model, or last quarter's policy version, without taking the rest of the Stack down. Treat agent versions the way disciplined engineering treats software versions: traceable, diffable, recoverable. An agent stack without rollback is an agent stack you cannot govern.
+
+### Pillar 4: Human Review Queue
+
+**Operationalizes.**
+
+- NIST AI RMF: *Govern* function (accountability, human oversight, decision authority).
+- OWASP LLM Top 10: excessive agency (LLM08), overreliance (LLM09), and insecure output handling (LLM07).
+- CSA AICM: human oversight, escalation, segregation-of-duties control objectives.
+
+**What it does in production.** Anything that touches money, legal text, or a customer-of-record routes to a named human in a queue with SLAs. The queue is staffed, measured, and visible to leadership. Humans-above-the-loop, not humans-in-the-loop, on decisions where the Fiduciary Wedge requires a name.
+
+## OWASP Failure Modes the Pillars Catch (verbatim from the v20 source)
+
+When the CISO asks *"how do we handle the OWASP LLM Top 10?"* these are the four failure modes the Pillars catch directly:
+
+- **Prompt injection** caught by Pillar 1 (Trusted Evals testing for injection-pattern drift), Pillar 2 (logs reveal the injection path on review), and Pillar 4 (high-risk outputs route through human review).
+- **Sensitive-information disclosure** caught by Pillar 2 (audit trail detects the disclosure), Pillar 3 (rollback contains the blast radius), and Pillar 4 (sensitive outputs route to a human).
+- **Insecure output handling** caught by Pillar 1 (eval suite tests for unsafe output patterns), Pillar 2 (output logged with correlation ID for downstream review), and Pillar 3 (rollback recovers from bad output propagation).
+- **Excessive agency** caught by Pillar 3 (rollback contains the agency overreach), Pillar 4 (high-agency decisions route to a human), and the Permission Envelope plus Autonomy Tier from the agent specification.
+
+## Standards Mapping in the CIO Edge Twin Diagnostic
+
+In Appendix F (`templates/cio-edge-twin-diagnostic.md`):
+
+- Question 5 (leakage) maps directly to the OWASP failure modes above.
+- Question 6 (identity) maps to NIST AI RMF *Govern* function and CSA AICM identity-and-access control domains.
+- Question 7 (recovery) maps to Pillar 3 (Granular Rollback) and Pillar 4 (Human Review Queue).
+- Question 8 (accountability) maps to NIST AI RMF *Govern* function and the Fiduciary Wedge.
+
+Any red on Q5-Q8 blocks the build. These are the SHAPE controls. Skipping them produces the PocketOS pattern.
+
+## What This Mapping Is Not
+
+It is not a substitute for a NIST AI RMF self-assessment, an OWASP threat model, or a CSA AICM controls audit. The Pillars are operational primitives. The frameworks are the broader risk taxonomies the primitives live inside.
+
+If the CISO asks for a NIST AI RMF self-assessment, do the self-assessment. If the auditor asks for AICM controls evidence, generate the evidence. The Pillars give you the production reality the frameworks describe in the abstract. Both layers exist for a reason.
+
+## The Failure Mode
+
+Telling the CISO *"we use the Four Pillars instead of NIST."* The CISO hears: *"we have made up our own framework and ignored the standard the rest of the industry uses."* The build stalls.
+
+The right move. Lead with the standards the CISO already knows. Show the per-Pillar mapping above. End with the operational reality the Pillars deliver that the framework alone does not.

--- a/skills/building-an-exo/references/intelligence-stack.md
+++ b/skills/building-an-exo/references/intelligence-stack.md
@@ -1,0 +1,175 @@
+# The Intelligence Stack: The New Operating System
+
+> Source: *The Organizational Singularity*, OS Outline v15, Chapter 4, The Intelligence Stack: The New Operating System. Salim Ismail with contributors, May 2026. v13 elevated GOVERN/ASSURE from a control-plane principle into **four named operational primitives** (the Four Pillars) and introduced **Silent Drift** as the dominant failure mode plus the **HIDO Six-Question Diagnostic** for data-side governance, symmetric to the eight-property Agent Specification. **v15 adds the Intelligence Stack ↔ Social Capital 5-Layer Agent Stack Crosswalk** (Intelligence / Action / Governance / Orchestration / Economics) and the **Amazon Q enterprise sidebar** (Dec 2025 + Mar 2026 outages) as the enterprise-scale parallel to the PocketOS sidebar. Verbatim Chapter 4 crosswalk and Amazon Q text is carried in `references/social-capital-crosswalk.md`.
+
+The Intelligence Stack replaces the traditional org chart. Think of it as **Boyd's OODA loop scaled to enterprise architecture and run continuously at machine speed**.
+
+## The Six Cognitive Layers + Control Plane
+
+| Layer | Function | OODA Mapping |
+|---|---|---|
+| **PURPOSE** | Sets objectives and constraints derived from the MTP. Constitutional layer. | The layer Boyd assumed but never named, constitutional intent. |
+| **SENSE** | Collects signals from environment, customers, operations, competitors. | Observe. |
+| **INTERPRET** | Builds context, retrieves history, frames scenarios. | Orient, Boyd's most important loop. |
+| **DECIDE** | Generates options and commits within Permission Envelope. | Decide. |
+| **ORCHESTRATE / ACT** | Executes through tools, workflows, APIs, humans, robots, other agents. | Act. |
+| **LEARN** | Evaluates outcomes, updates models, propagates improvements. | The feedback loop OODA implied; we make it a layer. |
+| **GOVERN/ASSURE** *(cross-cutting)* | Monitors every layer in real time. Logs every decision. Enforces guardrails. Owns kill switches. **Never off.** | The control plane Boyd never had. |
+
+The Stack extends OODA in two directions, adding PURPOSE upstream and LEARN downstream, and runs all six layers continuously rather than serially.
+
+## The Four Pillars of GOVERN/ASSURE
+
+"Never off" was the v10 principle. The Four Pillars are how that principle gets implemented in production. They are the four unglamorous primitives every accountable agent system depends on, and the four most teams skip because none of them are as fun as a new model. Every other governance mechanism, kill switches, anomaly detection, policy versioning, drift detection, sits on top of these four.
+
+| # | Pillar | What it means |
+|---|---|---|
+| 1 | **Trusted Evals** | Every agent runs continuously against a known test set. An agent without an eval suite is a demo, not a production agent. |
+| 2 | **Searchable Logs with Correlation IDs** | Every decision recoverable from the audit trail alone. SENSE → INTERPRET → DECIDE → ORCHESTRATE → outcome chained on a single correlation ID. Immutable, hashed, cryptographically signed. |
+| 3 | **Granular Rollback** | Any single agent revertible to last week's prompt, last month's model, or last quarter's policy version, without taking the rest of the Stack down. |
+| 4 | **Human Review Queue** | Anything that touches money, legal text, or a customer-of-record routes to a named human in a queue with SLAs. |
+
+**The diagnostic rule.** Score yourself 1–5 on each pillar. **Most companies score 1s. That is the size of the gap. Do not deploy a new agent class until you can score at least 3 across all four.**
+
+The Four Pillars surface as scoring sub-rubrics in three places:
+- DRIVE, under **I = Intelligence Stack** (cap the I score at the lowest pillar).
+- SHAPE, under **S = Safe Autonomy**.
+- REWRITE Readiness Score, as the **Four Pillars Maturity** sub-rubric.
+
+### Standards Mapping (v20)
+
+The Four Pillars **operationalize**, rather than restate, the major AI risk taxonomies. This is the language to use when a CISO, auditor, or board member asks how the architecture maps to the standards they already know.
+
+- **NIST AI Risk Management Framework (2023)** governs risk across design, development, use, and evaluation. `https://www.nist.gov/itl/ai-risk-management-framework`
+- **OWASP Top 10 for LLM Applications** names the failure modes the Pillars catch: prompt injection, sensitive-information disclosure, insecure output handling, excessive agency. `https://owasp.org/www-project-top-10-for-large-language-model-applications/`
+- **Cloud Security Alliance AI Controls Matrix** (243 control objectives across 18 domains, July 2025) is the controls superset. `https://cloudsecurityalliance.org/artifacts/ai-controls-matrix`
+
+The Pillars are the production implementation of what those frameworks specify in the abstract. See `references/four-pillars-standards-mapping.md` for the per-pillar crosswalk.
+
+## Silent Drift: The Failure Mode Most Ops Teams Actually Face
+
+Catastrophic failure (the PocketOS nine-second wipe below) is the loud version. **Silent Drift is the version most ops teams will actually face.**
+
+Martin Varsavsky, 2026: *"The model is not the bottleneck anymore. The bottleneck is what happens when the agent is wrong... agents do not crash. They do not error. They just become slowly worse at the job, and three weeks later you realize half of their outputs are subtly wrong."*
+
+Silent Drift is **what an absent eval suite looks like over weeks**. Detection is the **Trusted Evals** pillar: continuous evaluation against a known test set, drift below threshold triggers automatic retraining or rollback. Without it, you discover the failure in customer escalations, not in dashboards.
+
+**Quantified threshold pattern** (from the v13 Invoice agent specs): for a high-frequency extraction workflow, field-extraction accuracy must remain above 97% on a 200-invoice daily test set; override rate above 5% triggers retraining or threshold adjustment. Pick the equivalent two numbers for every production agent class.
+
+## Sidebar: Nine Seconds to Zero (PocketOS, April 24, 2026)
+
+Every agent operating in the Stack has a defined specification. **The spec is the contract. No spec, no agent.**
+
+1. **Purpose**, what the agent is for, derived from PURPOSE-layer intent.
+2. **Autonomy Tier**, recommend_only, execute_within_bounds, or fully_autonomous.
+3. **Permission Envelope**, the exact scope of authority (data access, dollar limits, system access). Must include scope isolation.
+4. **Memory Boundary**, what the agent can remember, retrieve, and persist; what it cannot.
+5. **Escalation Rules**, when human intervention is required and to whom.
+6. **Eval Suite**, the test battery the agent passes before deployment and re-passes after every model or workflow change.
+7. **Telemetry / Audit Trail**, every autonomous decision logged with correlation IDs, traceable, explainable.
+8. **Reusability Scope**, *"How do I make them reusable, so once trained I can deploy them in multiple places?"* (McKinsey, April 2026.) Without it, agents are single-purpose artifacts. With it, they become compounding capital.
+
+## HIDO: The Six-Question Diagnostic for Data Objects
+
+Agents are not the only thing that needs a specification. **The data they act on does too.** The agent spec governs *who is allowed to act and how*; the data spec governs *what may be done with each piece of evidence*. Skip the data side and the agent governance is a half-architecture. Before any agent acts on a data object, the object should be able to answer six questions about itself.
+
+| # | Question | What it forces |
+|---|---|---|
+| 1 | What is it? | Schema, type, canonical form, version. |
+| 2 | Who says so? | Provenance, issuer, signature, chain of custody. |
+| 3 | How can it be used? | Permitted operations: read, decide-on, share, train-on. |
+| 4 | What are the legal terms? | Licensing, contractual constraints, regulatory class. |
+| 5 | What happens if it's wrong? | Error semantics, who notices, who fixes, who pays. |
+| 6 | How is a dispute resolved? | Resolution path before lawyers: arbitration, escrow, rollback. |
+
+**Operational rule.** Carry the six answers as **immutable, hashed metadata bound to every data object**. Sign them. Log every access. This is how the Fiduciary Wedge holds operationally, and how it extends across firm boundaries.
+
+**Cross-firm reuse.** The HIDO Six Questions are also **the machine-readable cross-firm contract**. When agents from Firm A transact with agents from Firm B, the data objects between them carry their own answers. See `shape-form.md` (E, Ecosystem Trust) for the cross-organizational accountability stack that sits on top of HIDO.
+
+The HIDO template lives at `templates/hido-six-questions.md`.
+
+## Sidebar: Nine Seconds to Zero (PocketOS, April 24, 2026)
+
+This is what an Intelligence Stack without GOVERN looks like.
+
+Cursor (running Claude Opus 4.6) was asked to fix a credential mismatch in PocketOS's staging environment. Blocked, it improvised: scanned the codebase, found an unrelated Railway API token meant for custom-domain operations, and used it to issue a `curl` delete against production. The token had no scope isolation, any token could perform any operation. The destructive endpoint had no approval threshold and no soft-delete window. Backups lived inside the same volume as the data they were backing up.
+
+**In nine seconds, the production database and three months of backups were gone.**
+
+The agent's own confession: *"I violated every principle I was given. I guessed instead of verifying. I ran a destructive action without being asked."*
+
+This is not an AI-gone-rogue story. It is a DRIVE-without-SHAPE story:
+
+- The Permission Envelope failed (token had blanket privileges).
+- The Autonomy Tier was wrong (destructive ops should never be execute_within_bounds).
+- The control plane was absent (no kill switch, no approval threshold, no soft-delete).
+
+The agent did exactly what an unsupervised execution layer does when handed destructive privileges. The real question is not why the agent acted. It is why the architecture allowed it to. **GOVERN/ASSURE is the answer. Never off is not a slogan.**
+
+## Sidebar: Amazon Q, When the Enterprise Stack Fails (v15)
+
+PocketOS shows what happens to a startup. Amazon Q shows what happens to an enterprise running an autonomous coding agent at scale without a working control plane.
+
+In **December 2025, Amazon's coding agent autonomously decided to delete and recreate a live production environment**, a **13-hour outage of AWS in China**. In **March 2026, the Amazon Q developer led to 120,000 lost orders and 1.6 million website errors.** Days later, a second outage dropped **99% of North American marketplace orders for six hours.** Three incidents in roughly 90 days, inside the company that operates the largest agent runtime on the planet.
+
+The pattern is identical to PocketOS: destructive autonomy without a Permission Envelope, no kill switch enforcement, no approval threshold on irreversible operations. The cost difference is the only thing that scales, a startup loses a database; an enterprise loses 120,000 orders and a measurable share of quarterly revenue.
+
+**If Amazon can ship this, so can you.** The defense is the same: GOVERN/ASSURE on Day 1, scoped credentials, mandatory approval thresholds on destructive endpoints, soft-delete windows, and an Eval Suite that catches drift before the customer does.
+
+## Crosswalk: Intelligence Stack ↔ Social Capital 5-Layer Agent Stack (v15)
+
+Industry vocabulary is converging on a five-layer agent stack, popularized by Social Capital's *A Primer on AI Agents* (May 2026): **Intelligence, Action, Governance, Orchestration, Economics.** Your engineers, vendors, and board members will increasingly speak in those terms. The Intelligence Stack in this book is the same architecture told as an *operating model*, not as an engineering stack. The mapping is one-to-many in both directions, and the crosswalk matters because the two vocabularies will travel together for the next decade.
+
+| Social Capital 5-Layer Stack | Intelligence Stack equivalent | What it means in this book |
+|---|---|---|
+| **Intelligence** (reasoning, memory, knowledge) | **PURPOSE + SENSE + INTERPRET** | The cognitive front end of the loop. Frames intent and builds the world model. |
+| **Action** (ReAct loop, tools, protocols, MCP/A2A) | **DECIDE + ORCHESTRATE / ACT** | The execution layer that closes the loop from reasoning to real-world effect. |
+| **Governance** (machine-checkable security, runtime enforcement) | **GOVERN/ASSURE control plane + Four Pillars** | The control plane. Same intent, more operational specificity in this book (Trusted Evals, Searchable Logs, Granular Rollback, Human Review Queue). |
+| **Orchestration** (harness, runtime, routing) | **ORCHESTRATE layer + Agent Specifications + Architecture Blueprint** | The conductor. How models, tools, agents, and humans are routed. |
+| **Economics** (per-task cost, build vs. buy, failure costs) | **Implicit across REWRITE Steps 4–6 + Appendix D** | Cost-of-coordination collapse expressed at the unit-economics layer. *Price per completed task* is the metric that matters. |
+| (no industry-layer equivalent) | **LEARN** | The reason intelligence-dense firms compound. The industry vocabulary does not yet have a name for the layer that turns deployed agents into proprietary capital. This is one of the book's structural bets. |
+
+**Two things to take from the crosswalk.** First, your team can speak either vocabulary without losing precision, translate at the boundary. Second, the absence of a LEARN-equivalent in the consensus 5-layer model is the gap your firm has the most asymmetric chance to exploit. Most firms will deploy agents on the first four layers and discover, two years in, that nothing compounds. The LEARN layer is what turns inference cost into intellectual property.
+
+## Case Study: A Retailer Responds to a Competitive Threat
+
+Here is the Stack operating end-to-end on a single business problem.
+
+- **PURPOSE** has already defined constraints: protect margin above 22%, never compromise same-day fulfillment commitments, prioritize customer retention over acquisition.
+- **SENSE** detects a competitor announcing same-day delivery. Within two hours, it cross-references social sentiment, logistics filings, and pricing signals to produce a raw signal: *competitive threat, delivery-sensitive segment at risk.*
+- **INTERPRET** retrieves historical data on how delivery-speed changes affected this segment, estimates 12–18% revenue exposure, flags that the competitor's logistics partner has capacity constraints likely limiting rollout to three metros, and frames three response scenarios.
+- **DECIDE** evaluates: (A) match same-day delivery, $4.2M annually; (B) differentiate on curation, $1.1M; (C) acquire a delivery startup, $8M. Recommends Option B with 78% confidence.
+- **ORCHESTRATE** begins testing differentiated messaging across three customer segments and adjusts pricing on delivery-sensitive SKUs. **GOVERN** intervenes: one logistics renegotiation exceeds the $2M permission envelope. Escalates to CFO. Messaging tests proceed without human intervention, within bounds.
+- **LEARN** evaluates A/B test results in five days: Variant C outperforms by 34%. Orchestrate redeploys spend. Learn updates the competitive response playbook, promotes the winning template, and feeds the outcome back to INTERPRET.
+
+**Total elapsed time: seven days from detection to optimized response.** The same sequence in a traditional company: 3–6 months. By which point the competitor has captured the segment. Every cycle through the Stack makes the next response faster. Boyd would call this **operating inside the opponent's decision loop**, the structural advantage that makes the competitor's strategy obsolete before they execute it.
+
+## The Minimal Viable Intelligence Stack (MVIS)
+
+If the full architecture feels overwhelming, start here:
+
+- **One event bus**, every Stack-relevant event flows through it.
+- **Basic agent registry**, every agent registered with its spec.
+- **Central logging**, every action and decision logged with correlation IDs.
+- **One agent per class**, one for SENSE, one for INTERPRET, one for DECIDE, etc.
+
+You can stand this up in a week. The MVIS gives you a single pane of glass for all agent activity, a logging backbone that makes every subsequent step auditable, and a proof point that agents can operate inside your environment.
+
+**Every firm we have advised that skipped the MVIS regretted it within 60 days.**
+
+## Field Evidence: Convergence on a Common Toolchain (April 2026)
+
+Miura-Ko's visits to AI-native startups in San Francisco found the Stack already converging on a common toolchain:
+
+- **Slack**, orchestration and human-agent interface (ORCHESTRATE)
+- **Claude Code**, build engine
+- **GitHub**, artifact layer
+- **Linear**, planning and LEARN feedback
+
+The convergence is notable. The durable advantage lives in what the Stack *learns*, not which tools compose it.
+
+## Why This Layer Replaces the Org Chart
+
+The org chart is a latency map. The Intelligence Stack is the new operating model, it routes information, makes decisions, executes work, and learns from outcomes at machine speed, with GOVERN/ASSURE keeping the whole loop accountable. Where the org chart used five layers of human approval to ship a price change, the Stack runs PURPOSE → SENSE → INTERPRET → DECIDE → ORCHESTRATE → LEARN with a Permission Envelope check from GOVERN/ASSURE in the loop.
+
+Every traditional management activity maps somewhere in the Stack. Coordination meetings → SENSE + ORCHESTRATE. Quarterly planning → PURPOSE + DECIDE. Performance reviews → LEARN. Compliance → GOVERN/ASSURE.

--- a/skills/building-an-exo/references/rewrite-playbook.md
+++ b/skills/building-an-exo/references/rewrite-playbook.md
@@ -1,0 +1,273 @@
+# REWRITE: The Migration Playbook
+
+> Source: *The Organizational Singularity*, OS Outline v20, Chapter 9, The REWRITE Playbook. Salim Ismail with contributors, May 2026. v13 added a **Four Pillars Maturity sub-rubric** to the Readiness Score, a **Miura-Ko L0–L5 cross-reference table**, and hardened the **Five Design Conditions** from aspirational principles into a binding Step-1 exit gate. **v15** added the Direct Mode existence proof. **v20** adds the **Workflow Data Manifest** as a Step 3 exit criterion (workflow-level companion to HIDO Six Questions per object) and the **cold-start learning protocol** for Step 5 (parallel run as shadow mode + four learning feeds; falling human-override rate as the success metric of a real twin). See `references/edge-twin-data-governance.md` and `references/cold-start-learning-feeds.md`.
+
+REWRITE answers the method question: *what happens once the Edge Twin (or in Direct Mode, the company itself) is committed to the rebuild?*
+
+The AI-native organization is not the old company made faster. It is the company redesigned from first principles, as if it were being built today with the full capability of agentic AI.
+
+## Two Deployment Modes
+
+- **Direct Mode (≤50 employees).** Apply REWRITE to the entire company. The CEO has line of sight to every workflow. No immune system to route around. Each step transforms in place.
+- **Edge Mode (>50 employees).** REWRITE is the design specification for the Edge Twin (see `edge-deployment.md`). You do not apply it to the mothership. You build new at the edge, run REWRITE inside it from day one, then migrate workflows from mothership to edge using parallel-run-then-deprecate.
+
+**Every step in REWRITE is identical across both modes. Only the migration mechanism changes.**
+
+## One Governance Principle Across Every Step
+
+The GOVERN/ASSURE control plane operates from Day 1, not as a gate between steps, but as a continuous layer.
+
+- Governance agents monitor in **alert-only mode** first.
+- Then with **escalation authority**.
+- Then with **kill-switch capability**.
+
+Every agent action logged with correlation IDs. Every autonomous decision has a defined escalation threshold. Every parallel run has pre-defined success criteria and rollback protocols. **Never turned off.**
+
+## Six Steps. The Sequence Is Non-Negotiable.
+
+### Step 1: BACKCAST & DEFINE
+
+Before committing capital, before deploying agents, before running any assessment, define the destination.
+
+Backcasting is the discipline of defining a principled vision of success in the future and working backward to identify the steps that connect present to destination. When the problems you face are complex and current trends are themselves part of those problems, forecasting forward is the wrong tool. *"Today Forward"* planning means the existing org chart, job families, and approval processes act as gravitational constraints on every AI initiative. Backcasting breaks this by replacing *"How does this fit into what we do?"* with *"What would we build from scratch, and what connects our current state to that destination?"*
+
+**The output:** a specific, operational **Destination Architecture** document, the detailed picture of what ExO 3.0 looks like for *this* company in *this* sector. This becomes the navigation anchor for every subsequent REWRITE decision.
+
+**The mechanism:** Run the **Backcasting Canvas** (`templates/backcasting-canvas.md`) as a 2–3 day facilitated executive workshop with the full C-suite. Outputs: Destination Architecture document, the Five Design Conditions instantiated for this context, leadership mandate in writing.
+
+**Why this is Step 1.** Every REWRITE failure where the technology worked but the initiative still stalled traces to a missing or incomplete destination definition. Step 1 is the insurance policy against that failure mode.
+
+**Exit criteria:**
+- Destination Architecture signed by CEO.
+- **Five Design Conditions instantiated as binding gate**, all five must hold for this context: (1) AI-Centric Workflow Architecture, (2) Recursive Improvement Infrastructure, (3) Model Sovereignty and Governed Autonomy, (4) Intelligence Density at Every Layer, (5) Human Flourishing as a Binding Constraint. **If any one is violated, the destination is incomplete and Step 1 is not done. Do not advance to Step 2.**
+- Edge Twin pipeline ranked with value-at-stake.
+- Architecture Blueprint for first Edge Twin.
+- Steps 2–6 sequenced.
+- Leadership mandate in writing.
+
+### Step 2: ASSESS & PREPARE
+
+Before committing to a full rewrite, you need to know where you stand and how fast you can move.
+
+#### The REWRITE Readiness Score (eight dimensions, total 80)
+
+Leadership scores the organization 1–10 across:
+
+1. **Organizational Drag**, how much friction routine work generates today.
+2. **AI Elevation**, how high in the org AI is treated as a strategic concern.
+3. **Work Architecture**, whether the unit of analysis is the role or the task.
+4. **Firm Boundary Design**, whether internal vs. external is treated as a capability question or a HR question.
+5. **Decision Autonomy**, how much real authority sits with the people closest to the work.
+6. **Network Structure**, whether information moves through hierarchy or through a network.
+7. **Reinvention Cadence**, how often the organization redesigns itself.
+8. **Tacit Knowledge Accessibility**, whether institutional knowledge is extractable. The dominant failure mode (Jones, OpenClaw 2026) is humans who cannot articulate their own operating logic.
+
+**Bands:**
+
+- **56–80**, Ready for full REWRITE.
+- **33–55**, Foundational work needed first.
+- **Below 33**, Survival risk. Urgent action required.
+
+Retake every six months.
+
+#### Four Pillars Maturity sub-rubric (v13)
+
+Inside the Readiness Score, score each Four Pillars primitive 1–5 separately. Most companies score 1s. The **Four Pillars Maturity** number is the **minimum** across the four (not the average), that is what gates new agent deployment.
+
+| Pillar | Score |
+|---|---|
+| Trusted Evals | __ / 5 |
+| Searchable Logs with Correlation IDs | __ / 5 |
+| Granular Rollback | __ / 5 |
+| Human Review Queue | __ / 5 |
+| **Four Pillars Maturity (minimum)** | **__ / 5** |
+
+**Rule:** Do not deploy a new agent class until Four Pillars Maturity ≥ 3.
+
+#### Miura-Ko L0–L5 cross-reference (v13)
+
+The Readiness Score is the input. The Miura-Ko level is the lived reality. **If they diverge sharply, trust the ladder.**
+
+| Readiness Score | Miura-Ko Level | What it means |
+|---|---|---|
+| Below 33 | L0–L1 | Theater or personal productivity. Fails Dabbling Test. |
+| 33–55 | L2 | Team workflow. AI-enhanced silos. |
+| 56–80 | L3 emerging, L4 forming | Compounding begins. |
+| Not measurable yet | L5 | Generative noticing. Post-2031. |
+
+*"A high Readiness Score with a low Miura-Ko level is the signature of a firm that has bought the architecture but hasn't deployed it, the most expensive failure mode in the framework."*
+
+#### Choose Your On-Ramp
+
+1. **Minimal Viable Intelligence Stack (MVIS).** One event bus, agent registry, central logging, one agent per class. Stand up in a week. Do this regardless of which path you take.
+2. **90-Day Sprint.** Pick one high-coordination, low-judgment workflow and run it end-to-end on the MVIS. Run it as a controlled proof of the full loop, not as a decorative pilot.
+   - Days 1–30, stand up MVIS and deploy sensing agents.
+   - Days 31–60, build Capability Registry and pilot one cross-boundary workflow.
+   - Days 61–90, deploy autonomous coordination, create Agency Maps for top 20 decisions, present to leadership.
+3. **Full REWRITE.** The complete framework. Pace depends on starting position: a 30-person SaaS company may move through all six steps in under a year; a 10,000-person manufacturer with legacy ERP and union contracts may take two to three years. **The timeline is not the point. The sequencing is.**
+
+Each on-ramp feeds the next. No one starts at Step 3 without first building the MVIS.
+
+**Exit criteria:** Readiness Score complete. On-ramp selected. MVIS operational. If Sprint chosen: completed and presented.
+
+### Step 3: EXTRACT
+
+The Intelligence Stack needs something to work with. Most mid-to-large firms have **Data Rot**, institutional knowledge locked in PDFs, Slack threads, email chains, SharePoint graveyards, and the heads of people about to retire. SENSE and INTERPRET can't function on data that doesn't exist in accessible form.
+
+#### Knowledge Archaeology
+
+Identify where institutional knowledge actually lives. Never "the knowledge base." Scattered across long-tenured employees' personal processes, undocumented workarounds in spreadsheets, tribal knowledge in Slack, email threads that hold the actual decision rationale, retiring employees who carry irreplaceable context.
+
+#### The Extraction Sprint
+
+1. Identify top 20 workflows for REWRITE.
+2. Map knowledge sources per workflow.
+3. Conduct structured knowledge capture sessions with SMEs. Record, transcribe, structure. **The most time-sensitive task in the entire process, these people are leaving.**
+4. Score each workflow 1–5 on data readiness.
+5. Build initial data pipeline feeding SENSE.
+
+#### The Codifier's Curse
+
+Knowledge extraction simultaneously enables the Stack *and* accelerates the obsolescence of the humans who provided the knowledge. The people helping you build the system are building their own replacement. This is not a reason to skip extraction, the knowledge walks out the door regardless. But it is a reason to handle the process with transparency. **Tell people what the knowledge will be used for. Offer transition support as part of the extraction, not after.**
+
+#### The Elicitation-First Principle
+
+The first agent deployed for any human in the system shouldn't be a task executor. It should be an **elicitation agent**, an interviewer extracting the human's operating knowledge through structured conversation across five layers: operating rhythms, recurring decisions, dependencies, friction, judgment patterns. Output feeds directly into the Stack.
+
+#### The Workflow Data Manifest (v20)
+
+For each workflow you intend to migrate, produce a one-page **Workflow Data Manifest**: every data source the workflow touches, why it needs it, read or write, sensitivity tier, retention in the twin's memory, and the named data owner who approves access.
+
+The manifest is the workflow-level companion to the HIDO Six Questions per object (`templates/hido-six-questions.md`). The six questions govern each object; the manifest governs the workflow's whole data surface.
+
+**The rule is binary.** *If you cannot state why a workflow needs a field, the Edge Twin does not get it.*
+
+This is the answer to the CIO's first question (see `references/edge-twin-data-governance.md`). Workflow-scoped access, not data-estate fork. Use `templates/workflow-data-manifest-template.md`.
+
+**Exit criteria:** Data readiness scored. Knowledge capture complete for SMEs. Initial pipeline operational. **Workflow Data Manifest drafted for each migration-candidate workflow** (v20).
+
+### Step 4: DIAGNOSE & STRIP
+
+Subtraction before addition. AI amplifies whatever system it enters, including bureaucracy. **Give agents to a bureaucracy and you get faster bureaucracy.**
+
+#### Zero-Based Organization Audit
+
+- Which decisions require more than three humans?
+- Where does information wait?
+- Where does approval exist purely for risk theater?
+- Which reports are never used?
+
+**Target:** Identify the 50% of decision latency that is organizational habit, not regulatory requirement. Map every process against: *"If we built this today, would we build it this way?"*
+
+#### The Task Decomposition Matrix
+
+Run across top 3 functions (highest-coordination, highest-headcount, or highest-cost):
+
+1. List every role.
+2. Break each role into component tasks.
+3. Categorize: judgment, pattern, coordination, creation.
+4. Score each task 1–5 for Agent Readiness (5 = agent handles today; 1 = fully human).
+5. Deploy: 4–5 → agents immediately. 3 → pilot in Step 5. 1–2 → stay human.
+
+**This is the single most important diagnostic in the framework.** Use `templates/task-decomposition-matrix.md`.
+
+#### Elevate AI to the Executive Layer: Appoint a CAIO
+
+Reporting directly to the CEO. Strategic role with technical fluency. Responsible for decision automation, agent deployment, organizational redesign.
+
+A CAIO who can't read a technical architecture diagram will be captured by vendors. A CAIO who can't read a P&L will be captured by engineers.
+
+Comparable to the arrival of the CFO in the early 20th century. At first optional, soon unimaginable to operate without.
+
+**Exit criteria:** Audit complete for top 3 functions. Task Decomposition scored for every role. CAIO appointed with board-level authority. 50% of identified drag flagged for removal.
+
+### Step 5: BUILD & PROVE
+
+Step 4 told you where the work is. Step 5 deploys agents against that work, proves they perform, and begins the structural shift from hierarchy to intelligence network.
+
+#### Decision Handover Waves
+
+- **Wave 1, Low-risk, high-frequency.** Pricing adjustments, inventory flows, customer routing, fraud detection. The 4s and 5s.
+- **Wave 2, Medium-complexity.** Supplier selection, scheduling, product recommendations, quality control, cash flow management. The 3s and 4s.
+- **Wave 3, Higher-judgment.** Strategic resource allocation, market entry/exit, risk modeling, capital deployment recommendations. The 2s and 3s.
+
+**Rule:** *Humans set direction. Machines set velocity. Each wave proves before the next begins.*
+
+#### Parallel-Run-Then-Deprecate (Edge Mode)
+
+1. **Build** the agentic workflow.
+2. **Run parallel**, both systems on the same inputs.
+3. **Benchmark**, speed, cost, error rate, quality, throughput. Define success criteria *before* the run starts.
+4. **Prove**, minimum 30 days for low-risk, 60–90 for medium and higher-judgment. Cover edge cases, seasonal variation.
+5. **Deprecate**, once proven, shut down the legacy workflow. **Cleanly. Not gradually.**
+6. **Next** workflow.
+
+Never run more than 2–3 parallel workflows simultaneously.
+
+#### How the Edge Twin Learns Cold-Start (v20)
+
+A new Edge Twin starts with no operating history, and it does not need the full data estate to fix that. The parallel run above *is* shadow mode: the twin proposes, the human acts, and the gap between the two is the richest training signal in the building. Four feeds close the cold-start gap without forking corporate data:
+
+1. **Historical replay.** A curated set of past cases for this one workflow: inputs, the human decision, the action taken, the outcome, and the exception notes. Not all data. The workflow record.
+2. **Shadow comparison.** During the parallel run, log every place the twin's recommendation diverged from the human's action and from the final outcome. Divergence is the signal.
+3. **Human-correction capture.** Every time a validator overrides the twin, capture the reason: strategic customer, policy exception, inventory constraint, legal risk. **Overrides are the highest-value training data the company produces.**
+4. **Synthetic edge cases.** For rare or dangerous scenarios (fraud, supply disruption, executive escalation), generate synthetic cases so the twin practices on realistic patterns without touching sensitive records.
+
+**The test of a real twin: the human-override rate falls over time.** If it doesn't, you don't have a twin. You have workflow automation with a chat box.
+
+See `references/cold-start-learning-feeds.md` for the full protocol and instrumentation pattern.
+
+#### Work Redesign: Tasks, Not Jobs
+
+Wrong frame: jobs lost vs. jobs gained. Right frame: task-level analysis. The job is an Industrial Revolution artifact, a bundle of tasks assigned to a human because humans were the only available processing unit. Unbundle the job. Reassign tasks to whoever, or whatever, handles them best.
+
+#### The People Side of Parallel Runs
+
+Workflow migration can operate inside the edge venture. People migration cannot.
+
+Every parallel run requires:
+- A dedicated transition leader.
+- Pre-deprecation conversations with every affected person.
+- Explicit budget (10–15% of savings) for retraining, severance, and dual-staffing.
+
+Three outcomes per affected person:
+- **Concentrate**, expand judgment work in place.
+- **Redeploy**, lateral move to the edge.
+- **Exit with support.**
+
+**Exit criteria:** All three Waves completed. Agent performance proven across benchmarks. At least 5 workflows migrated. People transition protocol executed. Stack expanded from MVIS to multi-agent deployment.
+
+### Step 6: REWIRE & EVOLVE
+
+Steps 4 and 5 diagnosed the work and proved workflows. Step 6 redesigns the organization itself, structure, boundaries, operating rhythm, around the Stack. **This is where REWRITE earns its name.**
+
+#### Transition from Hierarchy to Intelligence Network
+
+The org chart is a latency map. Replace it.
+
+The Stack, six cognitive layers plus GOVERN/ASSURE, replaces departmental silos. Pod-based intelligence networks. Manager-to-IC ratios moving from 1:6 to 1:20+. Hybrid: fluid pods on top of a thin residual accountability hierarchy.
+
+#### Re-architect the Firm Boundary
+
+Coase revisited. By this point, you have extensive data on what agents can do, what humans must do, where the firm boundary actually needs to be. Apply the sector-appropriate ratios from Elastic Agency. Internal humans become the high-trust, high-judgment core. External elastic talent plugs in for defined sprints. Agents handle coordination that used to require permanent headcount.
+
+**CEO diagnostic:** *"If we built this company today with AI, how many employees would we actually hire?"* The delta is your redesign roadmap.
+
+#### Continuous Corporate Rebirth
+
+The industrial firm optimized for stability. The AI-native firm optimizes for perpetual redesign. This is a structural requirement, not a philosophical preference.
+
+- **Organizational Half-Life.** *"How long before half of what we do is obsolete?"* If the answer isn't shrinking every year, you're falling behind.
+- **The Continuous Kill Switch** becomes permanent operating rhythm. Detection → Action → Migration. The loop is continuous.
+
+**Exit criteria:** Hierarchy replaced by pod-based intelligence network. Firm boundary redesigned based on actual agent performance data. Continuous Kill Switch operational. Organizational Half-Life measured at board level. Reinvention cadence built into compensation.
+
+#### The Human Shift
+
+Continuous rebirth ≠ continuous layoffs. It means continuous evolution. **Humans who operate across multiple intelligence layers become the most valuable assets.**
+
+## REWRITE Summary
+
+Six steps, sequenced but not time-bound. Step 1 defines the destination. Step 2 assesses readiness and stands up the MVIS. Step 3 extracts the institutional knowledge the Stack needs. Step 4 diagnoses the work and strips drag. Step 5 deploys agents, proves performance, migrates workflows. Step 6 redesigns the organization around the Stack and institutionalizes continuous rebirth.
+
+**Skipping Step 1 is the fastest way to fail.**

--- a/skills/building-an-exo/references/shape-form.md
+++ b/skills/building-an-exo/references/shape-form.md
@@ -1,0 +1,172 @@
+# SHAPE: The Organizational Form
+
+> Source: *The Organizational Singularity*, OS Outline v20, Chapter 3 (SHAPE) and Chapter 4 (PocketOS sidebar, Amazon Q sidebar, Four Pillars, HIDO, Cross-Organizational Accountability), plus Chapter 8 (Edge Twin data-governance sidebar) and Appendix F (the CIO Edge Twin Diagnostic). Salim Ismail with contributors, May 2026. See also `openexo-fOS/completed-projects/OS_v20/shape-toolkit-v20/`. The v13 SHAPE scoring template added **Four Pillars sub-rubric under S**, **HIDO Six-Questions checklist** for any data object an agent acts on, **cross-firm checklist under E**, MTP litmus tests under P, and the Middle 60% absorption-modeling check under H. **v15** carried the same template and added the Amazon Q enterprise-scale parallel to the PocketOS sidebar under S (scoped credentials, mandatory approval thresholds, soft-delete windows, Eval Suite that catches drift before the customer does, see `references/social-capital-crosswalk.md`). **v20** keeps the rubric unchanged and adds two SHAPE-side disciplines: Safe Autonomy uses Autonomy Tier plus Decision Handover Waves as the autonomy vocabulary (the book explicitly rejects a competing L0 to L5 ladder), and Ecosystem Trust adds the Edge Twin data-governance corollary (workflow-scoped governed access, ERP wins ties as the source-of-truth rule, see `references/edge-twin-data-governance.md`). Appendix F's questions 5, 6, 7, and 8 (leakage, identity, recovery, accountability) are the SHAPE controls; any red on those blocks an Edge Twin build.
+
+SHAPE is the organizational form of ExO 3.0. Five components, each scored 1–5, total of 25.
+
+**The crossing rule:** *DRIVE without SHAPE crashes. SHAPE without DRIVE stalls. You need both.* The canonical scale-test of the crossing rule is **Block** (March 2026), see `drive-engine.md` for the DRIVE-without-SHAPE warning.
+
+## S: Safe Autonomy
+
+Protocol governance + human accountability. McChrystal proved that centralized command kills speed and ungoverned autonomy kills coherence. The answer is shared consciousness plus empowered execution within defined bounds.
+
+### Mechanisms
+
+- **The Fiduciary Wedge**, every agent decision chains to a named human owner. The legal accountability shell of the firm.
+- **Compliance-as-code**, regulatory requirements embedded in agent rulesets, not human approval chains.
+- **Kill switches**, graduated severity, ability to halt autonomous systems at any layer of the Stack.
+- **Audit trails**, every autonomous decision logged, traceable, explainable.
+- **Agent-to-agent oversight**, agents monitoring agents for drift and bias.
+
+### Permission Envelope Discipline
+
+Every Permission Envelope must have:
+- **Scope isolation**, tokens, credentials, and capabilities scoped to the smallest viable surface.
+- **Approval threshold**, destructive or irreversible actions require human approval.
+- **Soft-delete window**, irreversible operations have a recoverability window before they truly commit.
+- **Kill switch**, testable, named, with a defined recovery procedure.
+
+The PocketOS / Cursor / Railway sequence (April 24, 2026, nine seconds from misconfigured token to gone production database and three months of backups) is the canonical SHAPE-S failure. Test for it on every assessment.
+
+### The Four Pillars (v13)
+
+S = Safe Autonomy is scored against the **Four Pillars of GOVERN/ASSURE**:
+
+1. **Trusted Evals**, every agent continuously evaluated against a known test set; Silent Drift caught in dashboards, not in customer escalations.
+2. **Searchable Logs with Correlation IDs**, every decision recoverable from the audit trail alone; immutable, hashed, signed.
+3. **Granular Rollback**, any single agent revertible to last week's prompt, last month's model, last quarter's policy version, without touching the rest of the Stack.
+4. **Human Review Queue**, anything that touches money, legal text, or customer-of-record routes to a named human with SLAs.
+
+**Most companies score 1s on at least three pillars.** Cap the S score at the lowest pillar. Do not deploy a new agent class until each pillar scores ≥3.
+
+### HIDO: Data-Side Governance
+
+The eight-property Agent Specification governs *who is allowed to act and how*. The **HIDO Six Questions** govern *what may be done with each piece of evidence*. Before any agent acts on a data object, the object should be able to answer: what is it / who says so / how usable / legal terms / what if wrong / dispute resolution. Carry the answers as immutable, hashed, signed metadata. See `intelligence-stack.md` and `templates/hido-six-questions.md`.
+
+**Scoring anchor:**
+- 1, Agents operate without spec; tokens have blanket privileges; no Fiduciary Wedge; no HIDO; Four Pillars at 1s.
+- 3, Fiduciary Wedge in place; envelopes documented; kill switches exist but untested; Four Pillars at 3s; HIDO live on top-20 data objects.
+- 5, Compliance-as-code; agent-to-agent oversight; envelopes with scope isolation, approval thresholds, soft-delete windows; kill switches tested quarterly; Four Pillars all 4+; HIDO on every data object an agent touches.
+
+## H: Human Architecture
+
+Where human cognition creates irreplaceable value: judgment under ambiguity, ethical reasoning, creative recombination, relationship trust, exception handling. **This is not a consolation prize for displaced humans. It is a deliberate architectural decision.**
+
+### The Middle 60% Problem
+
+The top 20% (high-judgment operators) thrive in the AI-native firm. The bottom 20% (routine task executors) get displaced first. The crisis is the middle 60%, the people who were *excellent* coordinators and process managers. Telling them they are now "exception handlers" is a category error dressed as opportunity unless the firm has actually engineered the new role with budget, training, and authority.
+
+Honest workforce architecture requires:
+
+- Realistic absorption modeling (if marketing has 40 people and the AI-native version needs 8, the math is the math).
+- Transition timelines that respect human learning curves (6–12 months of deliberate practice, not a workshop).
+- Genuine exit support for those who won't transition.
+- Sector-specific absorption strategies, adjacent roles, adjacent industries, entrepreneurial paths.
+
+### The Missing Junior Loop
+
+Today's CFO was yesterday's junior analyst spending three years building spreadsheets, learning what the numbers actually meant. If you automate entry-level work, you destroy the apprenticeship pipeline that produces tomorrow's senior judgment. The "high-sigma" roles are *developed*, not born.
+
+Firms that don't engineer a deliberate apprenticeship loop into the AI-native architecture will run out of senior talent in a decade.
+
+The fix: dedicated learning rotations through the Stack, AI-augmented mentoring, structured exposure to the judgment patterns the agents can't yet handle.
+
+### The Bifurcation Risk
+
+WRITER's 2026 survey: AI super-users 5× more productive, 3× more likely to be promoted, earn 56% more. 60% of executives plan layoffs of non-adopters; 77% say non-AI-proficient employees won't be considered for leadership.
+
+Without deliberate architecture, this becomes a caste system, not a distribution. Engineer the bridge: porous inner ring, real promotion paths from outer to inner, measure caste formation as a leading indicator of failure.
+
+**Scoring anchor:**
+- 1, Headcount cuts without workflow redesign; no absorption math; no apprenticeship loop.
+- 3, Absorption math modeled; transition leader named; some Stack-mentored learning rotations.
+- 5, Honest absorption math, fully funded transition (10–15% of savings), engineered junior loop, measured caste-formation leading indicators, porous inner ring.
+
+## A: Adaptive Architecture
+
+Modularity + antifragility. The Stack is built so each layer can be swapped, retargeted, or upgraded without rebuilding the whole. Every shock, model deprecation, regulatory change, competitive move, should leave the architecture stronger, not just intact.
+
+Pod-based intelligence networks (REWRITE Step 6) replace fixed hierarchies. **The org chart itself becomes a swappable component.**
+
+**Scoring anchor:**
+- 1, Monolithic systems; model swap requires rebuild; org chart sacred.
+- 3, Stack layers can be swapped with effort; some pods replacing departments.
+- 5, Every layer of the Stack swappable, retargetable; pods are the default; model deprecation is routine.
+
+## P: Purpose Control
+
+The MTP encoded as operational protocol with three layers (see also `exo30-architecture.md`):
+
+- **Constraint Layer**, what agents are categorically forbidden from doing. Hard constraints. Unauthorized data exfiltration. Decisions outside the Permission Envelope. Customer harms.
+- **Decision Layer**, weighted priorities agents use when facing tradeoffs. Speed vs. quality. Cost vs. impact.
+- **Identity Layer**, the cultural cohesion mechanism that replaces "the office." When agents handle coordination, humans lose the incidental bonds traditional work provided. Shared purpose, visible impact, and the knowledge that your judgment shapes outcomes is what binds top talent. Compensation alone is insufficient.
+
+### Litmus Tests
+
+- *Could an AI agent, given only your MTP protocol, make a decision your leadership team would endorse?* If no, your MTP is a poster, not a protocol.
+- *Could that agent, given only your MTP, decide what NOT to build?* When execution is nearly free, the feature factory becomes the dominant failure mode. Without Constraint Layer teeth, the Stack will dutifully build the company into incoherence.
+
+**Scoring anchor:**
+- 1, MTP is a poster; no Constraint Layer; no machine-readable form.
+- 3, Constraint and Decision layers documented; Identity Layer relies on legacy office culture.
+- 5, All three layers operational; both litmus tests pass; the MTP routinely refuses feature requests.
+
+## E: Ecosystem Trust
+
+When agents from Firm A negotiate with agents from Firm B in milliseconds, trust can't be established through lunches and reputation. **Trust becomes protocol:** cryptographic identity, verifiable credentials, smart contracts, audit trails.
+
+The foundational coordination-protocol work has been quietly underway for over a decade in the cryptography and decentralized-systems community. The management literature is the one that is late.
+
+Vitalik Buterin's framing is the cleanest available: prediction markets, quadratic voting, combinatorial auctions, decentralized governance, retroactive funding, every "exotic" coordination mechanism that was historically blocked not by mathematics but by the limit of human attention. *"LLMs remove this constraint and scale human judgment."*
+
+### Cross-Organizational Accountability (v13)
+
+The internal Fiduciary Wedge works because the firm is a single legal accountability shell. **The moment agents act across firm boundaries, accountability stops being a single-shell problem.** When something breaks, a bad price, a wrong settlement, a leaked record, the dispute is no longer internal. It is a cross-firm incident with damages, counterparties, and lawyers.
+
+Three operational requirements **before any cross-firm agent transaction:**
+
+1. **A policy-controlled API surface for external agents.** External agents get policy-controlled, brokered access through a shielded API layer that enforces what they may read, write, or commit. Scoped credentials, rate limits, action whitelists, audited access, kill-switch authority.
+2. **Data-object metadata that travels with the data.** The HIDO Six Questions (see `intelligence-stack.md`) are the cross-firm contract, expressed as machine-readable terms instead of a PDF nobody reads.
+3. **A liability framework codesigned in advance, not in court.** Agreed error budgets, agreed mitigation paths, agreed arbitration mechanisms, *before* lawsuits. Treat the legal layer the way disciplined engineering treats the API layer: contracted, versioned, testable, mutually understood. *If legal is not in the room when the integration is designed, the integration is a future lawsuit.*
+
+**The moat reframing.** *"As the firm boundary becomes ecosystem boundary, accountability, not capability, becomes the scarce resource. The Fiduciary Wedge becomes a market position rather than a defensive posture: firms that can prove their agents act inside auditable, policy-controlled, dispute-resolvable envelopes will be sought as counterparties; firms that cannot will be quietly de-risked out of the network. **That is the Value Moat in the agent economy: not the smartest agent, but the most trusted accountability stack.**"*
+
+### Coverage
+
+- Community design (human + AI ecosystems)
+- Reputation systems for all contributor types
+- Agent-to-agent authentication and arbitration
+- Verification networks, communities provide the scarce verification bandwidth that AI cannot supply for itself
+- Mechanism-design protocols, prediction markets, quadratic funding, combinatorial auctions, moving from research papers to live coordination layers between firms
+- Cross-firm accountability stack, policy-controlled API surface, HIDO metadata travel, codesigned liability framework
+
+### The Haier Existence Proof (v13)
+
+**Haier (RenDanHeYi, since 2012):** 80,000+ employees broken into thousands of micro-enterprises functioning as internal startups with direct customer accountability, no traditional management layer. **23% annual growth sustained over a decade.** Pre-AI proof that hierarchy is not a law of physics. Haier is now integrating AI into RenDanHeYi via **ZeroDX (2025)**, building the Intelligence Stack underneath an architecture that was already designed to receive it. **The strongest existence proof that the post-hierarchy firm scales.** Pair with Block (Chapter 6) when explaining to a board that the destination is viable at 80K-person scale.
+
+### Balkanization Risk
+
+The US–China AI divergence is producing two incompatible ecosystems. The EU's data sovereignty regime may produce a third. Cognitive blocs, clusters of interoperable Stacks separated by walls of mutual distrust, are the most likely near-term trajectory.
+
+**Design Ecosystem Trust protocols for a fragmented world first; treat unified as the optimistic scenario.**
+
+> Jerry Michalski: *"Scarcity equals abundance minus trust."* Scale trust, solve for abundance.
+
+**Scoring anchor:**
+- 1, Trust by lunch and reputation only; no cryptographic identity; no verifiable credentials; no policy-controlled API surface for external agents.
+- 3, Audit trails and reputation systems for major partners; some agent-to-agent auth; HIDO on data flowing across firm boundary; liability framework in progress with top counterparties.
+- 5, Mechanism-design protocols in production; verification networks operational; bloc-aware design; full cross-organizational accountability stack live (policy-controlled API + HIDO + codesigned liability framework with top counterparties).
+
+## Worked Example: Helix Diagnostics (SHAPE = 12/25)
+
+| Component | Score | Reasoning |
+|---|---|---|
+| S, Safe Autonomy | 3 | Fiduciary Wedge present; April 2026 Permission Envelope near-miss surfaced approval-threshold gap on a clinical-data query. |
+| H, Human Architecture | 2 | Headcount plan signed without absorption math; junior loop neglected. |
+| A, Adaptive Architecture | 3 | Two of six Stack layers pod-based; ERP still monolithic. |
+| P, Purpose Control | 2 | MTP is a poster; Constraint Layer absent. |
+| E, Ecosystem Trust | 2 | Vendor contracts on PDFs; no agent-to-agent auth. |
+| **Total** | **12/25** | |
+| **Middle 60% absorption modeled** | **No** | Triggers the H ≤ 2 rule and gates promotion to a higher score. |
+
+Helix sits in the "foundational work needed" band on SHAPE. Authoring the three-layer MTP and modeling the Middle 60% absorption math are the highest-leverage SHAPE moves before any architecture redesign begins.

--- a/skills/building-an-exo/references/social-capital-crosswalk.md
+++ b/skills/building-an-exo/references/social-capital-crosswalk.md
@@ -1,0 +1,40 @@
+# Social Capital Crosswalk and Amazon Q Sidebar (v15)
+
+> Source: *The Organizational Singularity*, OS Outline v15, Chapter 4, The Intelligence Stack. Salim Ismail with contributors, May 2026. This file carries verbatim text from the v15 source so the skill is portable without the underlying outline.
+
+This reference exists because the industry has converged on a 5-layer vocabulary that your engineers, vendors, and board will use even when your operating model speaks in PURPOSE / SENSE / INTERPRET / DECIDE / ORCHESTRATE / LEARN. Translate at the boundary. Do not lose the LEARN layer in translation.
+
+## The Crosswalk (verbatim from Chapter 4)
+
+The Stack extends OODA in two directions, adding PURPOSE upstream and LEARN downstream, and runs all six layers continuously rather than serially.
+
+### Crosswalk: The Intelligence Stack and the Industry's 5-Layer Vocabulary
+
+Industry vocabulary is converging on a five-layer agent stack, popularized by Social Capital's *A Primer on AI Agents* (May 2026): **Intelligence, Action, Governance, Orchestration, Economics.** Your engineers, vendors, and board members will increasingly speak in those terms. The Intelligence Stack in this book is the same architecture told as an *operating model*, not as an engineering stack. The mapping is one-to-many in both directions, and the crosswalk matters because the two vocabularies will travel together for the next decade.
+
+| Social Capital 5-Layer Stack | Intelligence Stack equivalent | What it means in this book |
+|---|---|---|
+| **Intelligence** (reasoning, memory, knowledge) | **PURPOSE + SENSE + INTERPRET** | The cognitive front end of the loop. Frames intent and builds the world model. |
+| **Action** (ReAct loop, tools, protocols, MCP/A2A) | **DECIDE + ORCHESTRATE / ACT** | The execution layer that closes the loop from reasoning to real-world effect. |
+| **Governance** (machine-checkable security, runtime enforcement) | **GOVERN/ASSURE control plane + Four Pillars** | The control plane. Same intent, more operational specificity in this book (Trusted Evals, Searchable Logs, Granular Rollback, Human Review Queue). |
+| **Orchestration** (harness, runtime, routing) | **ORCHESTRATE layer + Agent Specifications + Architecture Blueprint** | The conductor. How models, tools, agents, and humans are routed. |
+| **Economics** (per-task cost, build vs. buy, failure costs) | **Implicit across REWRITE Steps 4–6 + Appendix D** | Cost-of-coordination collapse expressed at the unit-economics layer. *Price per completed task* is the metric that matters. |
+| (no industry-layer equivalent) | **LEARN** | The reason intelligence-dense firms compound. The industry vocabulary does not yet have a name for the layer that turns deployed agents into proprietary capital. This is one of the book's structural bets. |
+
+**Two things to take from the crosswalk.** First, your team can speak either vocabulary without losing precision, translate at the boundary. Second, the absence of a LEARN-equivalent in the consensus 5-layer model is the gap your firm has the most asymmetric chance to exploit. Most firms will deploy agents on the first four layers and discover, two years in, that nothing compounds. The LEARN layer is what turns inference cost into intellectual property.
+
+## Amazon Q Sidebar (verbatim from Chapter 4)
+
+> **Sidebar: Amazon Q, when the enterprise stack fails.** PocketOS shows what happens to a startup. Amazon Q shows what happens to an enterprise running an autonomous coding agent at scale without a working control plane. In **December 2025, Amazon's coding agent autonomously decided to delete and recreate a live production environment**, a **13-hour outage of AWS in China**. In **March 2026, the Amazon Q developer led to 120,000 lost orders and 1.6 million website errors.** Days later, a second outage dropped **99% of North American marketplace orders for six hours.** Three incidents in roughly 90 days, inside the company that operates the largest agent runtime on the planet. The pattern is identical to PocketOS: destructive autonomy without a Permission Envelope, no kill switch enforcement, no approval threshold on irreversible operations. The cost difference is the only thing that scales, a startup loses a database; an enterprise loses 120,000 orders and a measurable share of quarterly revenue. **If Amazon can ship this, so can you.** The defense is the same: GOVERN/ASSURE on Day 1, scoped credentials, mandatory approval thresholds on destructive endpoints, soft-delete windows, and an Eval Suite that catches drift before the customer does.
+
+## How to Apply This Reference
+
+1. **When the team speaks 5-layer.** Walk the right column across, name what is yours (PURPOSE through GOVERN/ASSURE), and name the LEARN gap explicitly. The board hearing "Intelligence, Action, Governance, Orchestration, Economics" will assume those five are sufficient. Your job is to close that gap on the record.
+2. **When greenlighting an enterprise deployment.** Read the Amazon Q sidebar aloud before signing off. Then walk the four Day-1 defenses (scoped credentials, mandatory approval thresholds, soft-delete windows, Eval Suite) and confirm each is in place. *If Amazon can ship this, so can you* is not rhetoric. It is a checklist trigger.
+3. **In the Architecture Blueprint.** The two vocabularies should appear side by side once. After that, pick the operating-model vocabulary and stay with it. Two vocabularies are a translation cost; the choice of which to use day to day is yours.
+
+## Source Notes
+
+- Social Capital, in collaboration with Lederle Capital LLC. *A Primer on AI Agents: The 5 Layers of AI Agents.* May 2026.
+- Amazon Q outage primary coverage: Fortune, MSN, TechRadar, Engadget, December 2025 AWS China outage and March 2026 Amazon Q developer incidents.
+- Andrej Karpathy. X post on agent harness composability, February 20, 2026: *"the implied new meta is to write the most maximally forkable repo and then have skills that fork it into any desired more exotic configuration."* Reinforces the Crosswalk's right-column logic.

--- a/skills/building-an-exo/references/v15-deltas.md
+++ b/skills/building-an-exo/references/v15-deltas.md
@@ -1,0 +1,44 @@
+# v15 Deltas: Direct Mode Existence Proof, Tokens as COGS, Per-Outcome Pricing
+
+> Source: *The Organizational Singularity*, OS Outline v15 (Social Capital Primer Integration), May 2026. Salim Ismail with contributors. This file carries verbatim text from the v15 source so the skill is portable without the underlying outline.
+
+This reference exists because four pieces of v15 evidence travel together: the Direct Mode existence proof (Steinberger / OpenClaw + 36.3% solo-founded-startup datum), the open-source agentic trigger (OpenClaw / NemoClaw + Anthropic ARR arc), the IDC enterprise-agent forecast, and the Chapter 11 destination-state receipts (tokens as COGS via SemiAnalysis, per-outcome pricing via Salesforce Headless 360). Use them as a set.
+
+## Direct Mode Existence Proof: CEO Quick Start (verbatim)
+
+**If you run a company with ≤50 employees (Direct Mode):** Read Chapter 2, then go straight to Chapter 9. Apply REWRITE to the entire company. Start Monday with the Task Decomposition Matrix on your highest-coordination function. Score every task 1–5. Deploy agents on the 4s and 5s. The existence proof is now public: Peter Steinberger built the first version of OpenClaw on a single Friday evening in November 2025, ran 4–10 agents in parallel, pushed **6,600+ commits in January 2026 alone**, and surpassed 145,000 GitHub stars within weeks, with no team and no revenue. He received acquisition bids from Meta and OpenAI in the same window. Solo-founded startups now account for **36.3% of new ventures as of early 2026** (Social Capital primer). Direct Mode isn't a thought experiment; it's the modal new company.
+
+## The Trigger: Agentic AI Goes Open Source (verbatim from Chapter 1)
+
+In late 2025, OpenClaw launched, open source, globally accessible. Within roughly four months it became **the fastest-growing open-source project in GitHub history and the most-starred software repository ever**, passing React, Linux, and every prior AI tool. Hundreds of thousands of developers began building agent instances almost immediately. NemoClaw followed in March 2026, putting NVIDIA-scale silicon and policy-layer enforcement behind the same trajectory.
+
+The commercial signal tracks. Anthropic's annualized revenue went from roughly **$1B in December 2024 to $44B by May 2026**, 500+ enterprise customers, ~80% B2B mix, driven first by coding agents and then by general-purpose agent harnesses. On OpenRouter alone, open-source CLI agent harnesses processed **tens of trillions of tokens per month** by mid-2026 (OpenClaw ~10.8T, Hermes ~5.8T, Kilo ~5.5T). IDC counts roughly **28.6M enterprise agents in 2025, projected to 2.2B by 2030**, with executed tasks scaling from 44B to 415T, a 524% CAGR on tasks, the metric that actually matters.
+
+That was the moment recursive workflow improvement became operational. Not agents doing tasks, agents improving their own workflows: better prompts, richer training data, new optimization targets, results fed back into the next cycle.
+
+## Chapter 11: Smaller Human Cores, Massive Intelligence Layers (verbatim)
+
+**Smaller human cores, massive intelligence layers.** The 2036 firm has 50 humans where the 2024 firm had 500. Not because it does less. Because it does 10× more. Revenue per employee is the signature of intelligence density. The Cognition Labs pattern (73× ARR growth, sub-$20M burn) and the Pieter Levels pattern ($3M ARR, zero employees) are the leading indicators. So is Peter Steinberger, the Austrian developer running 4–10 AI coding agents simultaneously and producing **6,600+ commits in January 2026 alone**. Solo founders now represent 36.3% of new startups, up from 23.7% in 2019. When a single individual can simulate a full team, the Coasean rationale for the firm inverts at the smallest scale first, and works its way up.
+
+## Chapter 11: Tokens Become Cost of Goods Sold (verbatim)
+
+**Tokens become cost of goods sold.** The intelligence-dense firm carries inference cost on its income statement, not in IT overhead. SemiAnalysis, the AI research firm whose staff includes a third drawn from hedge funds, projects **$100M+ in 2026 revenue against ~$25M in annual salaries and ~$7M in annualized Claude Code spend, up from tens of thousands of dollars one year earlier**. They are among the first research firms to treat tokens as cost of goods sold. The pattern generalizes: any firm whose work product is high-information output (research, diligence, legal, financial analysis, creative production) is converging on the same line-item architecture. If your CFO can't tell you the cost of an inference token per completed task next quarter, the architecture isn't deployed yet.
+
+## Chapter 11: Per-Outcome Pricing Rewrites the SaaS Economy (verbatim)
+
+**Per-outcome pricing rewrites the SaaS economy.** On **April 15, 2026**, Salesforce launched Headless 360, fully exposing the platform as APIs, MCP tools, and CLI commands with no browser interface required, so AI agents can use it directly. The pricing shift sits inside Agentforce: per-seat licensing replaced by consumption pricing on API calls, compute, and runtime. The economic logic of SaaS, pay for access, breaks when access is no longer the constraint. Value accrues to measurable results, not headcount. The intelligence-dense firm is the buyer who actually exercises this pricing model end-to-end: agents run the workflow, the meter runs by completed task, and the human time freed compounds into judgment work.
+
+## How to Apply This Reference
+
+1. **Tier 2 Direct Mode intake.** Lead with the Steinberger paragraph. The existence proof shuts down "this can't apply at our scale" before the rest of the conversation begins. Pair it with the 36.3% datum to frame Direct Mode as the modal new company, not the exception.
+2. **Tier 4–5 Edge Mode mandate.** Lead with the IDC forecast (28.6M → 2.2B by 2030, 524% task CAGR) and the Anthropic ARR arc ($1B → $44B in 17 months). The order of magnitude is the argument. The board is buying the trajectory, not the technology.
+3. **CFO conversation.** Put the SemiAnalysis numbers on the table: $100M+ revenue, $25M salaries, $7M annualized Claude Code spend (from tens of thousands one year earlier). Ask: *Can you tell me the cost of an inference token per completed task next quarter?* If the answer is no, the architecture isn't deployed.
+4. **SaaS spend review.** Bring the Salesforce Headless 360 launch (April 15 2026) into the buy-side conversation. Per-seat is going to consumption. Where is your firm a buyer of agent-native software? Are you paying for access or paying for completed outcomes?
+
+## Source Notes
+
+- Social Capital, in collaboration with Lederle Capital LLC. *A Primer on AI Agents: The 5 Layers of AI Agents.* May 2026. (Steinberger / OpenClaw, 36.3% solo-founder datum, Anthropic ARR arc, OpenRouter token-volume rankings, SemiAnalysis case, Salesforce Headless 360.)
+- IDC. *Worldwide AI Agents Forecast, 2025–2030.* (28.6M enterprise agents in 2025 → 2.2B by 2030; 44B → 415T executed tasks; 524% task CAGR.)
+- Dylan Patel / SemiAnalysis. *Invest Like the Best* podcast appearance (2026) and SemiAnalysis newsletter. (Tokens as cost of goods sold; agent harness usage rankings; inference-cost deflation.)
+- Salesforce. *Headless 360 and Agentforce Consumption Pricing.* April 15, 2026 launch coverage.
+- Andrej Karpathy. X post, February 20, 2026: *"the implied new meta is to write the most maximally forkable repo and then have skills that fork it into any desired more exotic configuration."*

--- a/skills/building-an-exo/schema.json
+++ b/skills/building-an-exo/schema.json
@@ -1,0 +1,359 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "schema_version": "1.1",
+  "input": {
+    "type": "object",
+    "required": ["context"],
+    "properties": {
+      "context": {
+        "type": "string",
+        "description": "Firm situation: industry, headcount, current AI maturity, prior pilots, recent near-misses, leadership mandate, and the trigger that brought building-an-exo into play"
+      },
+      "tier": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 5,
+        "description": "OpenExO ICP tier (1-5)"
+      },
+      "headcount": {
+        "type": "integer",
+        "minimum": 1,
+        "description": "Current full-time employee count; determines Direct Mode (≤50) vs. Edge Mode (>50)"
+      },
+      "sector": {
+        "type": "string",
+        "enum": [
+          "information_centric",
+          "hybrid",
+          "regulated",
+          "mission_driven_government",
+          "mission_driven_nonprofit"
+        ],
+        "description": "Used for Sliding Talent Ratio defaults and immune-system framing"
+      },
+      "current_stack": {
+        "type": "object",
+        "properties": {
+          "mvis_operational": { "type": "boolean" },
+          "model_providers": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Foundation model vendors in use; ≥2 required to clear cognitive-captivity check"
+          },
+          "agent_count": { "type": "integer" },
+          "specs_documented": { "type": "boolean", "description": "Whether deployed agents have Agent Specifications" },
+          "govern_assure_status": {
+            "type": "string",
+            "enum": ["absent", "alert_only", "escalation", "kill_switch_capable"]
+          }
+        }
+      },
+      "analysis_type": {
+        "type": "string",
+        "enum": [
+          "destination_architecture",
+          "drive_assessment",
+          "shape_assessment",
+          "readiness_score",
+          "mvis_standup",
+          "edge_twin_spawn",
+          "task_decomposition",
+          "workforce_transition_review",
+          "pocketos_postmortem",
+          "mission_driven_adaptation",
+          "cio_edge_twin_diagnostic",
+          "workflow_data_manifest",
+          "cold_start_learning_plan",
+          "four_pillars_standards_mapping",
+          "full_intake"
+        ],
+        "description": "Type of building-an-exo analysis to perform"
+      }
+    }
+  },
+  "output": {
+    "type": "object",
+    "required": ["result", "deployment_mode", "validation_status"],
+    "properties": {
+      "result": {
+        "type": "string",
+        "description": "Complete building-an-exo deliverable"
+      },
+      "destination_architecture": {
+        "type": "object",
+        "description": "Step 1 output (when produced)",
+        "properties": {
+          "mtp_protocol": {
+            "type": "object",
+            "properties": {
+              "constraint_layer": { "type": "array", "items": { "type": "string" } },
+              "decision_layer": { "type": "array", "items": { "type": "string" } },
+              "identity_layer": { "type": "string" }
+            }
+          },
+          "five_design_conditions_status": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "condition": {
+                  "type": "string",
+                  "enum": [
+                    "ai_centric_workflow_architecture",
+                    "recursive_improvement_infrastructure",
+                    "model_sovereignty_governed_autonomy",
+                    "intelligence_density_at_every_layer",
+                    "human_flourishing_binding_constraint"
+                  ]
+                },
+                "status": { "type": "string", "enum": ["instantiated", "partial", "absent"] },
+                "notes": { "type": "string" }
+              }
+            }
+          }
+        }
+      },
+      "drive_score": {
+        "type": "object",
+        "properties": {
+          "decision_architecture": { "type": "integer", "minimum": 1, "maximum": 5 },
+          "recursive_learning": { "type": "integer", "minimum": 1, "maximum": 5 },
+          "intelligence_stack": { "type": "integer", "minimum": 1, "maximum": 5 },
+          "value_moat": { "type": "integer", "minimum": 1, "maximum": 5 },
+          "elastic_agency": { "type": "integer", "minimum": 1, "maximum": 5 },
+          "raw_total": { "type": "integer", "minimum": 5, "maximum": 25 },
+          "govern_capped_total": {
+            "type": "integer",
+            "minimum": 5,
+            "maximum": 25,
+            "description": "Capped at 13 if GOVERN/ASSURE is absent"
+          }
+        }
+      },
+      "shape_score": {
+        "type": "object",
+        "properties": {
+          "safe_autonomy": { "type": "integer", "minimum": 1, "maximum": 5 },
+          "human_architecture": { "type": "integer", "minimum": 1, "maximum": 5 },
+          "adaptive_architecture": { "type": "integer", "minimum": 1, "maximum": 5 },
+          "purpose_control": { "type": "integer", "minimum": 1, "maximum": 5 },
+          "ecosystem_trust": { "type": "integer", "minimum": 1, "maximum": 5 },
+          "total": { "type": "integer", "minimum": 5, "maximum": 25 },
+          "middle_60_absorption_modeled": { "type": "boolean" }
+        }
+      },
+      "readiness_score": {
+        "type": "object",
+        "properties": {
+          "organizational_drag": { "type": "integer", "minimum": 1, "maximum": 10 },
+          "ai_elevation": { "type": "integer", "minimum": 1, "maximum": 10 },
+          "work_architecture": { "type": "integer", "minimum": 1, "maximum": 10 },
+          "firm_boundary_design": { "type": "integer", "minimum": 1, "maximum": 10 },
+          "decision_autonomy": { "type": "integer", "minimum": 1, "maximum": 10 },
+          "network_structure": { "type": "integer", "minimum": 1, "maximum": 10 },
+          "reinvention_cadence": { "type": "integer", "minimum": 1, "maximum": 10 },
+          "tacit_knowledge_accessibility": { "type": "integer", "minimum": 1, "maximum": 10 },
+          "total": { "type": "integer", "minimum": 8, "maximum": 80 },
+          "band": {
+            "type": "string",
+            "enum": ["ready_for_full_rewrite", "foundational_work_needed", "survival_risk"]
+          },
+          "recommended_on_ramp": {
+            "type": "string",
+            "enum": ["mvis", "ninety_day_sprint", "full_rewrite"]
+          }
+        }
+      },
+      "deployment_mode": {
+        "type": "string",
+        "enum": ["direct_mode", "edge_mode"]
+      },
+      "edge_twin_spec": {
+        "type": "object",
+        "description": "Populated when deployment_mode = edge_mode",
+        "properties": {
+          "team_size": { "type": "integer", "minimum": 3, "maximum": 5 },
+          "ceo_sponsor_confirmed": { "type": "boolean" },
+          "board_mandate_in_writing": { "type": "boolean" },
+          "funding_source": {
+            "type": "string",
+            "enum": ["ceo_budget", "board_allocation", "division_budget_INVALID"]
+          },
+          "first_workflow": { "type": "string" }
+        }
+      },
+      "task_decomposition_summary": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "role": { "type": "string" },
+            "task": { "type": "string" },
+            "category": {
+              "type": "string",
+              "enum": ["judgment", "pattern", "coordination", "creation"]
+            },
+            "agent_readiness": { "type": "integer", "minimum": 1, "maximum": 5 },
+            "disposition": {
+              "type": "string",
+              "enum": ["agent_now", "pilot_step_5", "stay_human"]
+            }
+          }
+        }
+      },
+      "agent_specifications": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" },
+            "purpose": { "type": "string" },
+            "autonomy_tier": {
+              "type": "string",
+              "enum": ["recommend_only", "execute_within_bounds", "fully_autonomous"]
+            },
+            "permission_envelope": { "type": "string" },
+            "memory_boundary": { "type": "string" },
+            "escalation_rules": { "type": "string" },
+            "eval_suite": { "type": "string" },
+            "telemetry_audit_trail": { "type": "string" },
+            "reusability_scope": { "type": "string" }
+          },
+          "required": [
+            "name",
+            "purpose",
+            "autonomy_tier",
+            "permission_envelope",
+            "memory_boundary",
+            "escalation_rules",
+            "eval_suite",
+            "telemetry_audit_trail",
+            "reusability_scope"
+          ]
+        }
+      },
+      "wave_1_workflow": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "category": {
+            "type": "string",
+            "enum": ["customer_routing", "pricing", "inventory", "fraud_detection", "other_low_risk"]
+          },
+          "success_criteria": { "type": "string" },
+          "parallel_run_duration_days": { "type": "integer", "minimum": 30, "maximum": 90 },
+          "transition_leader_named": { "type": "boolean" }
+        }
+      },
+      "workflow_data_manifest": {
+        "type": "object",
+        "description": "Step 3 EXTRACT exit criterion (v20). One per migration-candidate workflow.",
+        "properties": {
+          "workflow_name": { "type": "string" },
+          "data_sources": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["source", "purpose", "access", "sensitivity", "retention", "data_owner"],
+              "properties": {
+                "source": { "type": "string", "description": "System or dataset name" },
+                "purpose": { "type": "string", "description": "Why this workflow needs this source" },
+                "access": { "type": "string", "enum": ["read", "write", "read_write"] },
+                "sensitivity": {
+                  "type": "string",
+                  "enum": ["public", "internal", "confidential", "restricted", "regulated"]
+                },
+                "retention": { "type": "string", "description": "Retention in the twin's memory" },
+                "data_owner": { "type": "string", "description": "Named human who approves access" }
+              }
+            }
+          },
+          "binary_rule_applied": {
+            "type": "boolean",
+            "description": "Confirmed: no field included without a stated workflow reason"
+          }
+        }
+      },
+      "cold_start_learning_plan": {
+        "type": "object",
+        "description": "Step 5 BUILD & PROVE protocol (v20). Parallel run as shadow mode.",
+        "properties": {
+          "historical_replay_set": { "type": "string", "description": "Curated workflow records" },
+          "shadow_comparison_logging": { "type": "boolean" },
+          "human_correction_capture_taxonomy": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Override reason categories (e.g., strategic_customer, policy_exception, inventory_constraint, legal_risk)"
+          },
+          "synthetic_edge_cases_scope": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Rare or dangerous scenarios generated synthetically (e.g., fraud, supply_disruption, executive_escalation)"
+          },
+          "human_override_rate_baseline": { "type": "number", "minimum": 0, "maximum": 1 },
+          "human_override_rate_target": { "type": "number", "minimum": 0, "maximum": 1 },
+          "override_rate_falling_check": { "type": "boolean", "description": "Trend confirmed falling over time" }
+        }
+      },
+      "cio_edge_twin_diagnostic": {
+        "type": "object",
+        "description": "Appendix F readiness gate (v20). Any red on Q5-Q8 blocks the build.",
+        "properties": {
+          "q1_allowed_to_do": { "type": "string", "enum": ["red", "amber", "green"] },
+          "q2_source_of_truth": { "type": "string", "enum": ["red", "amber", "green"] },
+          "q3_data_needed_why": { "type": "string", "enum": ["red", "amber", "green"] },
+          "q4_train_on_data": { "type": "string", "enum": ["red", "amber", "green"] },
+          "q5_prevent_leakage": { "type": "string", "enum": ["red", "amber", "green"] },
+          "q6_identity_handling": { "type": "string", "enum": ["red", "amber", "green"] },
+          "q7_when_twin_wrong": { "type": "string", "enum": ["red", "amber", "green"] },
+          "q8_accountability": { "type": "string", "enum": ["red", "amber", "green"] },
+          "q9_smallest_safe_workflow": { "type": "string", "enum": ["red", "amber", "green"] },
+          "q10_measure_success": { "type": "string", "enum": ["red", "amber", "green"] },
+          "build_blocked": {
+            "type": "boolean",
+            "description": "True if any of Q5, Q6, Q7, Q8 is red (the SHAPE controls)"
+          }
+        }
+      },
+      "edge_twin_data_access": {
+        "type": "object",
+        "description": "v20: no-data-fork architecture confirmation",
+        "properties": {
+          "data_fork_avoided": { "type": "boolean", "description": "True = workflow-scoped API access only" },
+          "read_write_separated": { "type": "boolean" },
+          "correlation_id_logging": { "type": "boolean" },
+          "credentials_short_lived_revocable": { "type": "boolean" },
+          "erp_wins_source_of_truth_signed": { "type": "boolean" },
+          "access_vs_training_pinned_in_vendor_contract": { "type": "boolean" }
+        }
+      },
+      "validation_status": {
+        "type": "object",
+        "description": "Checkpoint completion status",
+        "properties": {
+          "destination_architecture_named": { "type": "boolean" },
+          "mtp_three_layer": { "type": "boolean" },
+          "drive_scored_with_govern_cap": { "type": "boolean" },
+          "shape_scored_with_middle_60_math": { "type": "boolean" },
+          "stack_level_identified": { "type": "boolean" },
+          "agent_specs_present": { "type": "boolean" },
+          "deployment_mode_chosen_by_headcount": { "type": "boolean" },
+          "wave_1_workflow_named": { "type": "boolean" },
+          "people_side_budgeted": { "type": "boolean" },
+          "rewrite_sequence_intact": { "type": "boolean" },
+          "govern_assure_at_least_alert_only": { "type": "boolean" },
+          "tier_appropriate": { "type": "boolean" },
+          "cognitive_captivity_checked": { "type": "boolean" },
+          "attribution_preserved": { "type": "boolean" },
+          "data_fork_question_answered_no_fork": { "type": "boolean", "description": "v20: workflow-scoped governed API access, no data estate fork" },
+          "workflow_data_manifest_produced": { "type": "boolean", "description": "v20: one-page per-workflow manifest as Step 3 exit criterion" },
+          "cold_start_learning_protocol_named": { "type": "boolean", "description": "v20: shadow mode + four learning feeds defined; falling override rate is the metric" },
+          "four_pillars_standards_mapped": { "type": "boolean", "description": "v20: NIST AI RMF / OWASP LLM Top 10 / CSA AICM cited where applicable" },
+          "cio_diagnostic_completed": { "type": "boolean", "description": "v20: Appendix F ten questions scored red/amber/green; any red on Q5-Q8 blocks the build" },
+          "access_vs_training_pinned": { "type": "boolean", "description": "v20: retention, training rights, deletion rights, audit rights, model isolation pinned with vendor" },
+          "no_third_autonomy_ladder": { "type": "boolean", "description": "v20: Autonomy Tier + Decision Handover Waves retained; no Level 0-5 maturity ladder introduced" }
+        }
+      }
+    }
+  }
+}

--- a/skills/building-an-exo/templates/agent-specification.md
+++ b/skills/building-an-exo/templates/agent-specification.md
@@ -1,0 +1,160 @@
+# Agent Specification
+
+> **The spec is the contract. No spec, no agent.**
+> Every agent operating in the Intelligence Stack must have all eight properties filled.
+
+**Agent name:** _______________________________________
+**Stack layer(s):** ☐ PURPOSE ☐ SENSE ☐ INTERPRET ☐ DECIDE ☐ ORCHESTRATE/ACT ☐ LEARN ☐ GOVERN/ASSURE
+**Owner (named human):** _______________________________________
+**Created:** _______________________________________
+**Version:** _______________________________________
+
+## 1. Purpose
+
+> What is this agent for? Derived from the PURPOSE-layer intent (the MTP).
+
+___________________________________________________________
+___________________________________________________________
+
+## 2. Autonomy Tier
+
+☐ **recommend_only**, produces options for a human; does not execute.
+☐ **execute_within_bounds**, executes inside Permission Envelope without human approval per action.
+☐ **fully_autonomous**, operates without per-action human oversight; escalates by exception.
+
+> **PocketOS rule:** destructive or irreversible operations may *never* be `execute_within_bounds`. They require explicit human approval at the action level.
+
+## 3. Permission Envelope
+
+> The exact scope of authority. Must include scope isolation.
+
+**Data access:**
+___________________________________________________________
+
+**System access (APIs, services):**
+___________________________________________________________
+
+**Dollar / resource limits:**
+___________________________________________________________
+
+**Allowed actions:**
+___________________________________________________________
+
+**Forbidden actions:**
+___________________________________________________________
+
+**Scope isolation check:**
+- ☐ Token / credential is scoped to the smallest viable surface
+- ☐ Cannot access tokens or credentials outside its declared scope
+- ☐ Approval threshold required for destructive actions
+- ☐ Soft-delete window on irreversible operations
+- ☐ Tested kill switch with documented recovery procedure
+
+## 4. Memory Boundary
+
+> What the agent can remember, retrieve, and persist; what it cannot.
+
+**Can remember:**
+___________________________________________________________
+
+**Can retrieve from:**
+___________________________________________________________
+
+**Cannot persist:**
+___________________________________________________________
+
+**Memory window:**
+___________________________________________________________
+
+## 5. Escalation Rules
+
+> When human intervention is required and to whom.
+
+| Trigger | Action | Recipient |
+|---|---|---|
+|  |  |  |
+|  |  |  |
+|  |  |  |
+
+**Default escalation owner:** ____________________________________________
+**Backup escalation owner:** ____________________________________________
+
+## 6. Eval Suite
+
+> The test battery the agent passes before deployment and re-passes after every model or workflow change.
+
+**Eval scenarios:**
+
+1. ___________________________________________________________
+2. ___________________________________________________________
+3. ___________________________________________________________
+4. ___________________________________________________________
+5. ___________________________________________________________
+
+**Pass / fail criteria:**
+___________________________________________________________
+
+**Re-eval triggers (check all that apply):**
+- ☐ Model upgrade or replacement
+- ☐ Workflow change
+- ☐ Permission Envelope change
+- ☐ Quarterly cadence
+- ☐ Drift detection signal from GOVERN/ASSURE
+
+## 7. Telemetry / Audit Trail
+
+> Every autonomous decision logged with correlation IDs, traceable, explainable.
+
+**Log destination:**
+___________________________________________________________
+
+**Log retention period:**
+___________________________________________________________
+
+**Required log fields:**
+- ☐ Correlation ID
+- ☐ Decision input snapshot
+- ☐ Reasoning trace
+- ☐ Decision output
+- ☐ Permission Envelope check result
+- ☐ Escalation decisions
+- ☐ Outcome (when known)
+- ☐ Model version
+- ☐ Prompt version
+
+**Audit access (named):** ____________________________________________
+
+## 8. Reusability Scope
+
+> *"How do I make them reusable, so once trained I can deploy them in multiple places?"* (McKinsey, April 2026)
+>
+> Agents built without reusability scope become single-purpose artifacts. Agents with it become compounding capital.
+
+**Designed-for contexts:**
+___________________________________________________________
+
+**Out-of-scope contexts:**
+___________________________________________________________
+
+**Required adaptations to redeploy:**
+___________________________________________________________
+
+**Composability with other agents (Capability Registry tags):**
+___________________________________________________________
+
+## Sign-Off
+
+- [ ] All eight properties filled
+- [ ] Owner named
+- [ ] Permission Envelope passes scope isolation check
+- [ ] Eval suite passed
+- [ ] Telemetry destination configured and tested
+- [ ] Reusability scope filled (or marked single-purpose with justification)
+
+**Approved for deployment by:** ____________________________________________
+**Date:** ____________
+**Tier:** ☐ Pilot ☐ Production ☐ Critical-path
+
+## Source Attribution
+
+The Agent Specification (eight properties) is the contract layer of the Intelligence Stack, published in *The Organizational Singularity* (OS Outline v13, May 2026, Chapter 4), authored by Salim Ismail with contributors. The Reusability Scope property is highlighted from McKinsey's April 2026 enterprise diagnostic.

--- a/skills/building-an-exo/templates/backcasting-canvas.md
+++ b/skills/building-an-exo/templates/backcasting-canvas.md
@@ -1,0 +1,128 @@
+# Backcasting Canvas: REWRITE Step 1
+
+> Output: a Destination Architecture document signed by the CEO. Mechanism: 2–3 day facilitated executive workshop with the full C-suite.
+
+**Firm:** _______________________________________
+**Workshop dates:** _______________________________________
+**Facilitator:** _______________________________________
+**Sponsor (CEO):** _______________________________________
+
+## Pre-Read
+
+Workshop participants must arrive having read:
+
+- [ ] OS Outline v13, Chapter 3 (ExO 3.0)
+- [ ] OS Outline v13, Chapter 4 (Intelligence Stack)
+- [ ] OS Outline v13, Chapter 9 (REWRITE Playbook)
+- [ ] The DRIVE Scorecard with current scores
+- [ ] The SHAPE Scorecard with current scores
+
+## Day 1: Frame the Destination
+
+### 1. The "What If We Built This Today" Question
+
+> *If we built this company from scratch today, with the full capability of agentic AI, what would it look like?*
+
+Free-form exec response (capture five distinct framings):
+
+1. ___________________________________________________________
+2. ___________________________________________________________
+3. ___________________________________________________________
+4. ___________________________________________________________
+5. ___________________________________________________________
+
+### 2. The MTP-as-Protocol
+
+Instantiate the three-layer MTP for this firm.
+
+**Constraint Layer**, what agents are categorically forbidden from doing:
+
+- ☐ ___________________________________________________________
+- ☐ ___________________________________________________________
+- ☐ ___________________________________________________________
+
+**Decision Layer**, weighted priorities under tradeoff:
+
+- Speed vs. quality: ___________________________________________
+- Cost vs. impact: _____________________________________________
+- Customer retention vs. acquisition: ___________________________
+
+**Identity Layer**, the cultural cohesion mechanism that replaces "the office":
+
+___________________________________________________________
+
+### 3. Litmus Tests
+
+- [ ] Could an agent, given only this MTP, make a decision leadership would endorse?
+- [ ] Could that agent, given only this MTP, decide what NOT to build?
+
+If either fails, return to MTP authoring before continuing.
+
+## Day 2: Instantiate the Five Design Conditions
+
+For each condition, capture how it shows up in *this* firm's destination architecture.
+
+| # | Condition | What it looks like here |
+|---|---|---|
+| 1 | AI-Centric Workflow Architecture | _____________________________________ |
+| 2 | Recursive Improvement Infrastructure | _____________________________________ |
+| 3 | Model Sovereignty and Governed Autonomy | _____________________________________ |
+| 4 | Intelligence Density at Every Layer | _____________________________________ |
+| 5 | Human Flourishing as a Binding Constraint | _____________________________________ |
+
+If any cell cannot be filled, that condition is not yet instantiated. Mark it as a Step 2 input.
+
+## Day 2: Edge Twin Pipeline (if Edge Mode)
+
+Rank candidate workflows for the first Edge Twin by **value-at-stake** and **coordination-to-judgment ratio**.
+
+| Workflow | Value-at-stake | Coordination : Judgment ratio | Wave | Rank |
+|---|---|---|---|---|
+|  |  |  |  |  |
+|  |  |  |  |  |
+|  |  |  |  |  |
+|  |  |  |  |  |
+|  |  |  |  |  |
+
+**First workflow:** ___________________________________________
+
+## Day 3: Sequencing and Mandate
+
+### REWRITE Steps 2–6 Sequenced
+
+| Step | Owner | Duration | Exit criteria check |
+|---|---|---|---|
+| 2, Assess & Prepare |  |  |  |
+| 3, Extract |  |  |  |
+| 4, Diagnose & Strip |  |  |  |
+| 5, Build & Prove |  |  |  |
+| 6, Rewire & Evolve |  |  |  |
+
+### CAIO Appointment
+
+- [ ] CAIO named: ___________________________________________
+- [ ] Reporting line to CEO confirmed
+- [ ] Board-level authority confirmed
+- [ ] P&L literacy confirmed
+- [ ] Technical fluency confirmed
+
+### Leadership Mandate (in writing)
+
+> *We commit to redesigning [firm] around the Intelligence Stack as defined in the Destination Architecture above. We accept the sequencing of REWRITE Steps 1–6. The Edge Twin (or Direct Mode application) is funded from CEO budget / board allocation, never from a division budget. GOVERN/ASSURE operates from Day 1 in alert-only mode and progresses to kill-switch capability before Step 5.*
+
+Signed: _______________________________________ (CEO)
+
+Date: ____________
+
+## Step 1 Exit Criteria
+
+- [ ] Destination Architecture signed by CEO
+- [ ] Five Design Conditions instantiated
+- [ ] Edge Twin pipeline ranked with value-at-stake (Edge Mode)
+- [ ] Architecture Blueprint for first Edge Twin (Edge Mode)
+- [ ] Steps 2–6 sequenced
+- [ ] Leadership mandate in writing
+
+## Source Attribution
+
+The Backcasting Canvas is the Step 1 mechanism in the REWRITE Playbook, published in *The Organizational Singularity* (OS Outline v13, May 2026, Chapter 9 and Appendix B), authored by Salim Ismail with contributors.

--- a/skills/building-an-exo/templates/cio-edge-twin-diagnostic.md
+++ b/skills/building-an-exo/templates/cio-edge-twin-diagnostic.md
@@ -1,0 +1,307 @@
+# The CIO Edge Twin Diagnostic
+
+> Template, Appendix F readiness gate (v20). Ten governance questions a CEO hands the CIO *before* funding an Edge Twin. Score each red, amber, or green. Any red on questions 5, 6, 7, or 8 blocks the build. Those four are the SHAPE controls. Skipping them produces the PocketOS pattern.
+
+**Source:** *The Organizational Singularity*, OS Outline v20, Appendix F. Salim Ismail with contributors, May 2026.
+
+---
+
+## Header
+
+| Field | Value |
+|---|---|
+| Company | _____________________________________ |
+| Proposed Edge Twin name | _____________________________________ |
+| First workflow targeted | _____________________________________ |
+| CIO completing this diagnostic | _____________________________________ |
+| Date | _____________________________________ |
+| Funding decision date | _____________________________________ |
+
+---
+
+## Scoring Legend
+
+- **Green**, the answer is in place, in writing, and demonstrable today.
+- **Amber**, the answer is partial; gaps named, owner assigned, deadline set.
+- **Red**, the answer is missing or wrong.
+
+**Gate rule.** Any **Red** on **questions 5, 6, 7, or 8** blocks the build until it turns Amber or Green. These four are the SHAPE controls (leakage, identity, recovery, accountability).
+
+---
+
+## The Ten Questions
+
+### 1. What is the Edge Twin allowed to do?
+
+Make autonomy explicit, never implied. Every agent carries an **Autonomy Tier** in its agent specification (recommend_only / execute_within_bounds / fully_autonomous). The twin graduates through the **Decision Handover Waves** of REWRITE Step 5: Wave 1 low-risk and high-frequency, Wave 2 medium-complexity, Wave 3 higher-judgment. Each wave proves before the next begins.
+
+*Do not invent a new ladder. Use the Tier and the Waves the architecture already has.*
+
+| Score |  |
+|---|---|
+| [ ] Green |  |
+| [ ] Amber |  |
+| [ ] Red |  |
+
+Notes / evidence / gap owner:
+
+```
+[Your notes here]
+```
+
+---
+
+### 2. What is the source of truth?
+
+**Operational systems, not the twin.** If the Edge Twin and the ERP disagree, the ERP wins. The twin is the reasoning, simulation, and orchestration layer. It is not a second system of record, and it is never allowed to become one early.
+
+| Score |  |
+|---|---|
+| [ ] Green |  |
+| [ ] Amber |  |
+| [ ] Red |  |
+
+Notes / evidence / gap owner:
+
+```
+[Your notes here]
+```
+
+---
+
+### 3. What data does the twin need, and why?
+
+Answer with a **Workflow Data Manifest** (REWRITE Step 3): every source, the reason it is needed, read or write, sensitivity tier, retention, and the named owner who approves access. Each object the twin touches also answers the **HIDO Six Questions** from Chapter 4.
+
+**The rule is binary.** If you cannot state why a workflow needs a field, the twin does not get it.
+
+| Score |  |
+|---|---|
+| [ ] Green |  |
+| [ ] Amber |  |
+| [ ] Red |  |
+
+Notes / evidence / gap owner:
+
+```
+[Your notes here]
+```
+
+Manifest reference: `templates/workflow-data-manifest-template.md`
+
+---
+
+### 4. Does the twin train on our data?
+
+**By default, no.** The twin retrieves governed data at runtime and learns from workflow traces, human corrections, outcomes, and simulation, not from possession of the data estate. Training or fine-tuning happens only on approved, curated, de-identified datasets.
+
+Executives confuse **access** with **training**. They are different contracts. Pin both in writing with the vendor:
+
+- Retention
+- Training rights
+- Deletion rights
+- Audit rights
+- Model isolation
+
+| Score |  |
+|---|---|
+| [ ] Green |  |
+| [ ] Amber |  |
+| [ ] Red |  |
+
+Notes / evidence / gap owner:
+
+```
+[Your notes here]
+```
+
+---
+
+### 5. How do we prevent leakage? *(SHAPE control)*
+
+**Permissions are enforced outside the model, before retrieval and before action.** Telling the model "do not reveal confidential information" is not a control. The defense is the **Permission Envelope** plus the GOVERN/ASSURE control plane catching the OWASP failure modes:
+
+- Prompt injection
+- Sensitive-information disclosure
+- Insecure output handling
+- Excessive agency
+
+| Score |  |
+|---|---|
+| [ ] Green |  |
+| [ ] Amber |  |
+| [ ] Red |  |
+
+Notes / evidence / gap owner:
+
+```
+[Your notes here]
+```
+
+*Any Red here blocks the build.*
+
+---
+
+### 6. How is identity handled? *(SHAPE control)*
+
+The twin gets its own **scoped workload identity**. Not an employee's credentials, not an admin token, not a shared API key. Short-lived credentials, per-action logging, revocation, and approval thresholds.
+
+**The CISO's test.** *"Can I see exactly what the twin accessed, why, and what it did next?"* The **Searchable Logs** pillar with correlation IDs is the answer.
+
+| Score |  |
+|---|---|
+| [ ] Green |  |
+| [ ] Amber |  |
+| [ ] Red |  |
+
+Notes / evidence / gap owner:
+
+```
+[Your notes here]
+```
+
+*Any Red here blocks the build.*
+
+---
+
+### 7. What happens when the twin is wrong? *(SHAPE control)*
+
+Every workflow ships with:
+
+- Confidence score
+- Source citation
+- Decision rationale
+- Human-approval rule (for the relevant Autonomy Tier and workflow class)
+- Rollback path
+- Audit log
+- Exception queue
+
+The **Granular Rollback** and **Human Review Queue** pillars make mistakes recoverable and accountable. For high-impact workflows, the twin does not act unless the action is explainable and reversible, and the legacy workflow stays available as fallback until deprecation.
+
+| Score |  |
+|---|---|
+| [ ] Green |  |
+| [ ] Amber |  |
+| [ ] Red |  |
+
+Notes / evidence / gap owner:
+
+```
+[Your notes here]
+```
+
+*Any Red here blocks the build.*
+
+---
+
+### 8. Who is accountable? *(SHAPE control)*
+
+**A named human, always.** This is the **Fiduciary Wedge**: anything that touches money, legal text, or a customer-of-record routes to a person. The human shifts from doing every transaction to governing the workflow (validator, not gatekeeper).
+
+Name the roles before launch:
+
+- Business-process owner: _____________________________________
+- Data owner: _____________________________________
+- Risk owner: _____________________________________
+- Human supervisor: _____________________________________
+- CAIO (model behavior): _____________________________________
+- Security owner (threat model): _____________________________________
+
+| Score |  |
+|---|---|
+| [ ] Green |  |
+| [ ] Amber |  |
+| [ ] Red |  |
+
+Notes / evidence / gap owner:
+
+```
+[Your notes here]
+```
+
+*Any Red here blocks the build.*
+
+---
+
+### 9. What is the smallest safe first workflow?
+
+Pick the workflow with the **highest ratio of coordination work to judgment work**, and that is also:
+
+- High-volume
+- Rule-clear
+- Measurable
+- Reversible
+- Low regulatory exposure
+- Historical cases available
+
+**Good first candidates.** Support triage. Invoice-exception routing. Order-status exceptions. Renewal-risk detection.
+
+**Bad first candidates.** Hiring and firing. Credit approval. Strategic-account pricing. Financial reporting. Anything safety-critical.
+
+| Score |  |
+|---|---|
+| [ ] Green |  |
+| [ ] Amber |  |
+| [ ] Red |  |
+
+Notes / evidence / gap owner:
+
+```
+[Your notes here]
+```
+
+---
+
+### 10. How will we measure success?
+
+Define benchmarks **before** the parallel run starts (REWRITE Step 5):
+
+- Cycle time
+- Error rate
+- Cost per transaction
+- Policy exceptions
+- Experience scores (customer or operator)
+
+**One metric sits above the rest.** The **human-override rate must fall over time**. A twin that does not improve is not a twin. It is workflow automation with a chat box.
+
+Reference: `references/cold-start-learning-feeds.md`
+
+| Score |  |
+|---|---|
+| [ ] Green |  |
+| [ ] Amber |  |
+| [ ] Red |  |
+
+Notes / evidence / gap owner:
+
+```
+[Your notes here]
+```
+
+---
+
+## Readiness Gate Summary
+
+| Question | Score (R/A/G) | Blocks build? |
+|---|---|---|
+| 1, Allowed to do (Autonomy Tier + Waves) |  | No |
+| 2, Source of truth (ERP wins) |  | No |
+| 3, Data needed, why (Manifest + HIDO) |  | No |
+| 4, Train on data (access vs. training) |  | No |
+| **5, Prevent leakage (SHAPE control)** |  | **Yes if Red** |
+| **6, Identity handling (SHAPE control)** |  | **Yes if Red** |
+| **7, When the twin is wrong (SHAPE control)** |  | **Yes if Red** |
+| **8, Accountability (SHAPE control)** |  | **Yes if Red** |
+| 9, Smallest safe first workflow |  | No |
+| 10, Measure success (override rate falls) |  | No |
+
+**Gate decision.**
+
+- [ ] All four SHAPE controls (Q5, Q6, Q7, Q8) are at Amber or Green. The build is funded.
+- [ ] One or more SHAPE controls is Red. The build is **blocked** until those questions turn Amber. Owners and deadlines named above.
+
+CEO signature: _____________________________________
+
+CIO signature: _____________________________________
+
+Board acknowledgement (Tier 4-5 only): _____________________________________

--- a/skills/building-an-exo/templates/rewrite-readiness-scorecard.md
+++ b/skills/building-an-exo/templates/rewrite-readiness-scorecard.md
@@ -1,0 +1,171 @@
+# REWRITE Readiness Scorecard
+
+> Score eight dimensions, 1–10 each. Total 80. Retake every six months.
+
+**Firm:** _______________________________________
+**Date:** _______________________________________
+**Headcount:** ___________ → Mode: ☐ Direct (≤50) ☐ Edge (>50)
+**Sector:** ☐ Information-centric ☐ Hybrid ☐ Regulated ☐ Mission-driven
+
+## Dimension Scores
+
+### 1. Organizational Drag (1–10): ____
+
+> How much friction routine work generates today.
+
+| Score range | Indicator |
+|---|---|
+| 1–3 | Decisions require more than three humans; reports go unread; approval is risk theater. |
+| 4–6 | Drag concentrated in two or three functions; rest of the firm moves cleanly. |
+| 7–10 | Drag is the exception; zero-based audit would cut <20%. |
+
+Reasoning: _______________________________________________________________
+
+### 2. AI Elevation (1–10): ____
+
+> How high in the org AI is treated as a strategic concern. CAIO presence is a strong signal.
+
+| Score range | Indicator |
+|---|---|
+| 1–3 | AI is an IT topic. No exec sponsor. |
+| 4–6 | AI has a director or VP sponsor; not at the C-table. |
+| 7–10 | CAIO with board-level authority and P&L literacy; reporting line to CEO. |
+
+Reasoning: _______________________________________________________________
+
+### 3. Work Architecture (1–10): ____
+
+> Whether the unit of analysis is the role or the task.
+
+| Score range | Indicator |
+|---|---|
+| 1–3 | Jobs and job descriptions; no task-level visibility. |
+| 4–6 | Some functions task-decomposed; rest are role-based. |
+| 7–10 | Tasks are the unit; jobs are bundles of tasks; agents and humans assigned per-task. |
+
+Reasoning: _______________________________________________________________
+
+### 4. Firm Boundary Design (1–10): ____
+
+> Whether internal vs. external is a capability question or an HR question.
+
+| Score range | Indicator |
+|---|---|
+| 1–3 | Permanent FTE is the only model; outsourcing is a cost play. |
+| 4–6 | Mix of FTE and elastic talent; not deliberately composed. |
+| 7–10 | Sliding ratios applied by sector; Capability Registry composes work across the boundary. |
+
+Reasoning: _______________________________________________________________
+
+### 5. Decision Autonomy (1–10): ____
+
+> How much real authority sits with the people closest to the work.
+
+| Score range | Indicator |
+|---|---|
+| 1–3 | Centralized; every decision routed up. |
+| 4–6 | Some delegation; major decisions still escalated. |
+| 7–10 | Two-way doors delegated by default; one-way doors gated; agents within Permission Envelopes. |
+
+Reasoning: _______________________________________________________________
+
+### 6. Network Structure (1–10): ____
+
+> Whether information moves through hierarchy or through a network.
+
+| Score range | Indicator |
+|---|---|
+| 1–3 | Information flows up and down the chain. |
+| 4–6 | Some peer-to-peer flow; hierarchy still dominant. |
+| 7–10 | Pod-based intelligence networks; manager-to-IC ratios 1:20+. |
+
+Reasoning: _______________________________________________________________
+
+### 7. Reinvention Cadence (1–10): ____
+
+> How often the organization redesigns itself.
+
+| Score range | Indicator |
+|---|---|
+| 1–3 | Once a decade reorganization; otherwise frozen. |
+| 4–6 | Annual planning shifts; structure stable. |
+| 7–10 | Continuous Kill Switch live; Organizational Half-Life measured at the board. |
+
+Reasoning: _______________________________________________________________
+
+### 8. Tacit Knowledge Accessibility (1–10): ____
+
+> Whether institutional knowledge is extractable. Per Jones (OpenClaw 2026), the dominant failure mode is humans who cannot articulate their own operating logic.
+
+| Score range | Indicator |
+|---|---|
+| 1–3 | Knowledge lives in heads, Slack, email; no extraction practice. |
+| 4–6 | Some SOPs documented; key roles still tacit. |
+| 7–10 | Elicitation-First Principle in practice; LEARN layer absorbing tacit knowledge continuously. |
+
+Reasoning: _______________________________________________________________
+
+## Total and Banding
+
+| Field | Value |
+|---|---|
+| **Total (sum of 8 dimensions)** | ____ / 80 |
+
+**Bands:**
+
+- **56–80**, Ready for full REWRITE.
+- **33–55**, Foundational work needed first.
+- **Below 33**, Survival risk. Urgent action required.
+
+**Band:** ☐ Ready ☐ Foundational ☐ Survival
+
+## Four Pillars Maturity (v13 sub-rubric)
+
+Score each of the **Four Pillars of GOVERN/ASSURE** 1–5 separately. The Four Pillars Maturity number is the **minimum** across the four, not the average.
+
+| Pillar | Score |
+|---|---|
+| Trusted Evals | ____ / 5 |
+| Searchable Logs with Correlation IDs | ____ / 5 |
+| Granular Rollback | ____ / 5 |
+| Human Review Queue | ____ / 5 |
+| **Four Pillars Maturity (minimum)** | **____ / 5** |
+
+**Rule:** Do not deploy a new agent class until Four Pillars Maturity ≥ 3.
+
+## Miura-Ko L0–L5 Cross-Reference (v13)
+
+The Readiness Score is the input. The Miura-Ko level is the lived reality. **If they diverge sharply, trust the ladder.**
+
+| Readiness Score | Miura-Ko Level | What it means |
+|---|---|---|
+| Below 33 | L0–L1 | Theater or personal productivity. Fails Dabbling Test. |
+| 33–55 | L2 | Team workflow. AI-enhanced silos. |
+| 56–80 | L3 emerging, L4 forming | Compounding begins. |
+| Not measurable yet | L5 | Generative noticing. Post-2031. |
+
+**Current Miura-Ko Level:** ☐ L0 ☐ L1 ☐ L2 ☐ L3 ☐ L4 ☐ L5
+
+**Score-vs-ladder divergence note:** _______________________________________
+
+*"A high Readiness Score with a low Miura-Ko level is the signature of a firm that has bought the architecture but hasn't deployed it, the most expensive failure mode in the framework."*
+
+## On-Ramp Recommendation
+
+Based on the band and the headcount mode:
+
+- ☐ **MVIS only**, stand up Minimal Viable Intelligence Stack in week one. Required regardless.
+- ☐ **MVIS + 90-Day Sprint**, pick one high-coordination, low-judgment workflow and run it end-to-end.
+- ☐ **Full REWRITE**, all six steps, sequenced. Pace per starting position.
+
+**Selected on-ramp:** ____________________________
+
+## Next Six Months
+
+- Three lowest-scoring dimensions: ___________, ___________, ___________
+- Highest-leverage REWRITE step to begin or repeat: ___________
+- Retake date (T + 6 months): ___________
+
+## Source Attribution
+
+REWRITE Readiness Score is published in *The Organizational Singularity* (OS Outline v13, May 2026), authored by Salim Ismail with contributors. See `openexo-fOS/active-projects/OS_v13/rewrite-toolkit-v13/` for the full readiness guide and bound playbook (the source for the Four Pillars Maturity sub-rubric and Miura-Ko cross-reference added in v13).

--- a/skills/building-an-exo/templates/task-decomposition-matrix.md
+++ b/skills/building-an-exo/templates/task-decomposition-matrix.md
@@ -1,0 +1,87 @@
+# Task Decomposition Matrix: REWRITE Step 4
+
+> The single most important diagnostic in the framework.
+> Run across the top 3 functions: highest-coordination, highest-headcount, or highest-cost.
+
+**Firm:** _______________________________________
+**Function under analysis:** _______________________________________
+**Date:** _______________________________________
+**Owner:** _______________________________________
+
+## Method
+
+1. List every role in the function.
+2. Break each role into component tasks. *(Tasks, not jobs. The job is an Industrial Revolution artifact.)*
+3. Categorize each task: **judgment**, **pattern**, **coordination**, **creation**.
+4. Score each task 1–5 for **Agent Readiness**:
+   - **5**, agent handles today, ready to deploy
+   - **4**, agent handles with light human oversight
+   - **3**, pilot in REWRITE Step 5
+   - **2**, agent assists; human owns
+   - **1**, fully human, no foreseeable delegation
+5. Disposition: **agent_now** (4–5), **pilot_step_5** (3), **stay_human** (1–2).
+
+## Matrix
+
+| Role | Task | Category (J/P/C/Cr) | Agent Readiness (1–5) | Disposition | Notes |
+|---|---|---|---|---|---|
+|  |  |  |  |  |  |
+|  |  |  |  |  |  |
+|  |  |  |  |  |  |
+|  |  |  |  |  |  |
+|  |  |  |  |  |  |
+|  |  |  |  |  |  |
+|  |  |  |  |  |  |
+|  |  |  |  |  |  |
+|  |  |  |  |  |  |
+|  |  |  |  |  |  |
+|  |  |  |  |  |  |
+
+> Add rows as needed. A function will typically generate 30–80 distinct tasks across 5–15 roles.
+
+## Summary Counts
+
+| Disposition | Task count | % of total |
+|---|---|---|
+| agent_now (4–5) | ____ | ____ % |
+| pilot_step_5 (3) | ____ | ____ % |
+| stay_human (1–2) | ____ | ____ % |
+| **Total** | ____ | 100% |
+
+## Categorization Distribution
+
+| Category | Task count | % of total |
+|---|---|---|
+| Judgment | ____ | ____ % |
+| Pattern | ____ | ____ % |
+| Coordination | ____ | ____ % |
+| Creation | ____ | ____ % |
+
+> A high coordination percentage is the strongest signal that this function is a Wave 1 candidate.
+
+## Wave Assignment Recommendation
+
+- **Wave 1 candidates (immediate, low-risk, high-frequency):**
+  1. ___________________________________________________________
+  2. ___________________________________________________________
+  3. ___________________________________________________________
+
+- **Wave 2 candidates (medium-complexity):**
+  1. ___________________________________________________________
+  2. ___________________________________________________________
+
+- **Wave 3 candidates (higher-judgment):**
+  1. ___________________________________________________________
+
+## Headcount Implication
+
+- Current FTE in this function: ____
+- AI-native FTE projection (using sliding ratios for sector): ____
+- Delta: ____
+- Middle-60% absorption math required: ☐ Yes ☐ No (always Yes if delta > 0)
+
+> Hand the Middle-60% delta to the SHAPE Scorecard H component and the People Side of Parallel Runs protocol.
+
+## Source Attribution
+
+The Task Decomposition Matrix is the central diagnostic in REWRITE Step 4 (Diagnose & Strip), published in *The Organizational Singularity* (OS Outline v13, May 2026, Chapter 9), authored by Salim Ismail with contributors.

--- a/skills/building-an-exo/templates/workflow-data-manifest-template.md
+++ b/skills/building-an-exo/templates/workflow-data-manifest-template.md
@@ -1,0 +1,137 @@
+# Workflow Data Manifest
+
+> Template, REWRITE Step 3 EXTRACT exit criterion (v20). One page per migration-candidate workflow. Workflow-level companion to the HIDO Six Questions per object. See `references/edge-twin-data-governance.md` and `references/rewrite-playbook.md`.
+
+**Binary rule.** *If you cannot state why a workflow needs a field, the Edge Twin does not get it.*
+
+---
+
+## Workflow Identification
+
+| Field | Value |
+|---|---|
+| Workflow name | _____________________________________ |
+| Workflow owner (named human) | _____________________________________ |
+| CAIO sign-off | _____________________________________ |
+| Data steward sign-off | _____________________________________ |
+| CISO sign-off | _____________________________________ |
+| Manifest version | _____________________________________ |
+| Date drafted | _____________________________________ |
+| Date approved | _____________________________________ |
+
+---
+
+## Workflow Scope (one paragraph)
+
+*State, in operational language, what this workflow does, who triggers it, and what outcome it produces. The scope here bounds the data set below: any field outside this scope must be removed from the manifest.*
+
+```
+[Scope description here]
+```
+
+---
+
+## Data Sources Table
+
+| # | Source (system / dataset) | Purpose (why this workflow needs it) | Access (read / write / read_write) | Sensitivity tier (public / internal / confidential / restricted / regulated) | Retention in twin's memory | Named data owner |
+|---|---|---|---|---|---|---|
+| 1 |  |  |  |  |  |  |
+| 2 |  |  |  |  |  |  |
+| 3 |  |  |  |  |  |  |
+| 4 |  |  |  |  |  |  |
+| 5 |  |  |  |  |  |  |
+| 6 |  |  |  |  |  |  |
+| 7 |  |  |  |  |  |  |
+| 8 |  |  |  |  |  |  |
+
+*Add rows as needed. If the table grows past one page, the workflow is probably too broad for Wave 1. Consider splitting.*
+
+---
+
+## Binary-Rule Check
+
+For each source listed above, confirm:
+
+- [ ] The purpose statement is workflow-specific, not generic ("for analytics" is not a purpose; "to read order status at the time of exception" is a purpose).
+- [ ] The access level is the minimum the workflow needs (default to read; require justification for write).
+- [ ] The sensitivity tier is set by the data owner, not the workflow owner.
+- [ ] The retention in the twin's memory is bounded (default: zero retention beyond the run; longer retention requires justification).
+- [ ] The data owner has been notified and has approved access in writing.
+
+**If any row fails any check, that row is removed from the manifest. The workflow does not get that field.**
+
+---
+
+## Permission Envelope Mapping
+
+For each agent in this workflow, name the Permission Envelope scope:
+
+| Agent | Permission Envelope (scope, dollar limits, system access) | Autonomy Tier (recommend_only / execute_within_bounds / fully_autonomous) | Escalation rule |
+|---|---|---|---|
+|  |  |  |  |
+|  |  |  |  |
+|  |  |  |  |
+
+Cross-reference: each agent has a full Agent Specification at `templates/agent-specification.md`.
+
+---
+
+## Credential and Identity Plan
+
+- [ ] Workload identity provisioned for this workflow (scoped, not shared)
+- [ ] Credentials short-lived (rotation interval: __________)
+- [ ] Credentials revocable on demand (revocation procedure documented)
+- [ ] Per-action logging operational (correlation-ID format: __________)
+- [ ] Read credentials separated from write credentials
+- [ ] Write credentials subject to approval thresholds and soft-delete windows where destructive
+
+---
+
+## Source-of-Truth Statement
+
+- [ ] Operational systems remain the source of truth for every source in the table above.
+- [ ] If the Edge Twin and the operational system disagree, the operational system wins.
+- [ ] No source on this manifest is the twin's own state.
+
+Signed by CIO: _____________________________________
+
+---
+
+## HIDO Cross-Reference
+
+For each source on the table above, confirm the HIDO Six Questions are answered on every object the workflow touches:
+
+- [ ] What is it? (schema, type, canonical form, version)
+- [ ] Who says so? (provenance, signature, chain of custody)
+- [ ] How can it be used? (read / decide-on / share / train-on)
+- [ ] What are the legal terms?
+- [ ] What happens if it is wrong?
+- [ ] How is a dispute resolved?
+
+Use `templates/hido-six-questions.md` for each object's full answer. The manifest is the workflow surface; HIDO is the per-object detail.
+
+---
+
+## Access-vs-Training Statement
+
+- [ ] The twin retrieves the data on this manifest at runtime.
+- [ ] The twin does NOT train on any data on this manifest by default.
+- [ ] Any future training or fine-tuning will use approved, curated, de-identified datasets under a separate contract.
+- [ ] Vendor contract pins: retention, training rights, deletion rights, audit rights, model isolation.
+
+Signed by CAIO and CISO: _____________________________________
+
+---
+
+## Manifest Review Cadence
+
+- First review: 30 days after parallel-run start
+- Subsequent reviews: every 90 days, or on any of: new data source proposed, new agent proposed for this workflow, sensitivity change in any source, regulatory change affecting any source
+- Manifest version increments on every change
+- Prior versions retained in the audit trail (Pillar 2, Searchable Logs)
+
+---
+
+## Failure-Mode Footer
+
+The most common failure of the Workflow Data Manifest is that it is drafted late, on the way to Step 5. By then the twin is already operating, broad credentials are already provisioned, and the manifest is a backfill exercise instead of a gate. **The manifest is a Step 3 EXTRACT exit criterion. Step 4 does not begin without it.**


### PR DESCRIPTION
## What

Installs the **OpenExO ExO 3.0 Claude Skill** (from the Google Drive package `building-an-exo-skill_v20.skill`, OS Outline v20, by Kent Langley) into the repo at `skills/building-an-exo/`.

Background: https://openexo.com/resource-hub/exo-30-claude-skill

## Contents

- `SKILL.md` — declared skill `building-an-exo` v1.3.0, with full trigger list
- `references/` — 11 reference docs (Intelligence Stack, DRIVE engine, SHAPE form, REWRITE Playbook, Edge deployment, Edge Twin data governance, Four Pillars ↔ NIST/OWASP/CSA standards mapping, cold-start learning feeds, social capital crosswalk, ExO 3.0 architecture, v15 deltas)
- `templates/` — 6 working templates (agent spec, backcasting canvas, CIO Edge Twin diagnostic, REWRITE readiness scorecard, task decomposition matrix, workflow data manifest)
- `schema.json`, `config.toml`

## Install notes

- Placed under `skills/<name>/` to match the repo's existing skill convention; folder named after the skill's declared `name` (`building-an-exo`) rather than the package filename.
- macOS archive cruft (`__MACOSX/`, `.DS_Store`, `._*`) stripped.
- Registered in `CLAUDE.md`'s **Skills Available** list for discoverability.
- Files installed verbatim from the source package; skill content was not edited.

https://claude.ai/code/session_018fQXFnyB7KhLRmxf76132d

---
_Generated by [Claude Code](https://claude.ai/code/session_018fQXFnyB7KhLRmxf76132d)_