### PR TITLE
ci: add Claude Code GitHub Actions workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,41 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read


### PR DESCRIPTION
Completes the `/install-github-app` setup.

The OAuth token secret (`CLAUDE_CODE_OAUTH_TOKEN`) was already created, but the workflow file that listens for `@claude` was missing — so the app was authorized but non-functional. This adds it.

**What it enables once merged:**
- `@claude` in an issue or PR comment/review triggers Claude Code
- `@claude` in a new issue title/body triggers it too
- Auth via the existing `CLAUDE_CODE_OAUTH_TOKEN` secret (no API key needed)

Uses `anthropics/claude-code-action@v1`. Untouched: existing `ci.yml` and `daily-dev-loop.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)